### PR TITLE
✅ Fix Issue #9: Remove incompatible PrimeVue CSS imports

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,8 +20,8 @@ import TabView from 'primevue/tabview'
 import TabPanel from 'primevue/tabpanel'
 
 // Import styles
-import 'primevue/resources/themes/aura-light-blue/theme.css'
-import 'primevue/resources/primevue.min.css'
+// PrimeVue 4+ uses built-in theme system via @primevue/themes/aura (imported above)
+// No need to import theme CSS manually
 import 'primeicons/primeicons.css'
 import '@fortawesome/fontawesome-free/css/all.css'
 


### PR DESCRIPTION
## 🎯 Описание

Исправлена критическая ошибка сборки из-за несовместимых импортов PrimeVue CSS.

## ❌ Проблема

Build падал с ошибкой:
```
Rollup failed to resolve import "primevue/resources/themes/aura-light-blue/theme.css"
```

## ✅ Решение

Удалены старые импорты PrimeVue 3:
```diff
- import 'primevue/resources/themes/aura-light-blue/theme.css'
- import 'primevue/resources/primevue.min.css'
+ // PrimeVue 4+ uses built-in theme system via @primevue/themes/aura
+ // No need to import theme CSS manually
```

## 📝 Детали

PrimeVue 4+ использует встроенную систему тем через `@primevue/themes/aura` (уже импортирован на строке 5). CSS темы генерируются автоматически, поэтому ручные импорты больше не нужны и вызывают ошибки.

## 🧪 Тестирование

Build прогресс после fix:
- ✅ PrimeVue CSS ошибка исправлена
- ⚠️ Обнаружена новая ошибка: отсутствует `@vueuse/core` (отдельный issue)

## 📁 Измененные файлы
- `src/main.js` (строки 23-24)

## 🔗 Связанные Issues
Fixes #9

---
🤖 Generated by Claude Code