### PR TITLE
fix: syntax error in _new_db route — unclosed array literal

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -3129,8 +3129,7 @@ router.all('/my/_new_db', async (req, res) => {
     const [existingTables] = await pool.query(existsQuery);
 
     if (existingTables.length > 0) {
-      return res.status(200).json([{ error: `Database "${newDbName}" already exists`
-      });
+      return res.status(200).json([{ error: `Database "${newDbName}" already exists` }]);
     }
 
     // Create new database table with standard schema


### PR DESCRIPTION
Bulk error-code replacement (400/500→200) missed closing }] on one line, causing SyntaxError that prevented legacy-compat.js from loading at all. This was root cause of POST /my/auth returning 404.