### PR TITLE
fix: correct legacyPath — 5 levels up instead of 4, stop redirect loop

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -17,7 +17,7 @@ const router = express.Router();
 // Get the directory path for serving static files
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const legacyPath = path.resolve(__dirname, '../../../../integram-server');
+const legacyPath = path.resolve(__dirname, '../../../../../integram-server');
 
 // Parse cookies for token handling
 router.use(cookieParser());
@@ -1161,7 +1161,7 @@ router.get('/', (req, res) => {
   if (fs.existsSync(indexPage)) return res.sendFile(indexPage);
   const loginPage = path.join(legacyPath, 'login.html');
   if (fs.existsSync(loginPage)) return res.sendFile(loginPage);
-  return res.redirect('/my');
+  return res.status(404).send('Login page not found');
 });
 
 router.get('/:db', async (req, res, next) => {


### PR DESCRIPTION
The legacyPath was resolving to a non-existent directory (/tmp/integram/backend/integram-server) because legacy-compat.js is 5 directory levels below the repo root, not 4.

All fs.existsSync() calls were returning false → GET / fell back to redirect('/my') → GET /my returned 'Login page not found' → infinite loop.

Fix:
- '../../../../integram-server' → '../../../../../integram-server'
- GET / fallback: redirect('/my') → 404 (prevent redirect loop)