### PR TITLE
fix: PHP parity for object page JSON response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,16 +3,3 @@ Your prepared branch: issue-65-c78c49fee862
 Your prepared working directory: /tmp/gh-issue-solver-1766761635421
 
 Proceed.
-
----
-
-Issue to solve: https://github.com/unidel2035/integram-standalone/issues/171
-Your prepared branch: issue-171-e03cdeb512a5
-Your prepared working directory: /tmp/gh-issue-solver-1772058705652
-Your forked repository: konard/unidel2035-integram-standalone
-Original repository (upstream): unidel2035/integram-standalone
-
-Proceed.
-
-
-Run timestamp: 2026-02-25T22:31:53.886Z


### PR DESCRIPTION
## Summary

This PR fixes PHP-to-Node.js response parity for the `/my/object/:typeId?JSON` endpoint by addressing two discrepancies:

1. **Removed `&main.&top_menu` from object page JSON response** - PHP's `object.html` template does NOT include the `&top_menu` block, so Node.js should not return it either.

2. **Added `&multiselectcell` block for multi-reference values** - PHP populates this block when a reference field has the `:MULTI:` modifier OR contains more than one referenced value.

### Issue Reference
Fixes #171

### Technical Details

**`&multiselectcell` block structure** (matching PHP format):
```json
{
  "id": ["230250"],        // row IDs
  "val": ["218246"],       // referenced object IDs
  "ord": ["2"],            // order values
  "name": ["<A HREF=\"/my/object/197000/?F_I=218246\" class=\"ms-link\">Name</A>"]
}
```

**Key changes in `legacy-compat.js`:**
- Updated SQL query to fetch `d.id` and `d.ord` for tracking multi-ref row data
- Added logic to detect multi-ref fields (`:MULTI:` flag or count > 1)
- Build `&multiselectcell` block with formatted `ms-link` class links
- Removed `buildTopMenu()` call from object page response

### Verification

- All 17 legacy-compat unit tests pass
- Syntax check passes

## Test plan
- [ ] Verify object page JSON response no longer includes `&main.&top_menu`
- [ ] Verify multi-reference fields now populate `&multiselectcell` block
- [ ] Compare response with PHP server on `/my/object/18?JSON` endpoint


🤖 Generated with [Claude Code](https://claude.com/claude-code)