### PR TITLE
feat: Schema Introspection API

### DIFF
--- a/services/core-data-service/src/index.js
+++ b/services/core-data-service/src/index.js
@@ -20,6 +20,7 @@ export * from './middleware/LegacyFormatTransformer.js';
 
 import { ObjectService } from './services/ObjectService.js';
 import { QueryService } from './services/QueryService.js';
+import { SchemaService } from './services/SchemaService.js';
 import { TypeService } from './services/TypeService.js';
 import { ValidationService } from './services/ValidationService.js';
 import { LegacyFormatTransformer } from './middleware/LegacyFormatTransformer.js';
@@ -71,6 +72,15 @@ export class CoreDataService {
       validationService,
     });
 
+    this.schemaService = new SchemaService(databaseService, {
+      typeService: this.typeService,
+      queryService: this.queryService,
+      objectService: this.objectService,
+    }, {
+      ...options,
+      validationService,
+    });
+
     this.validationService = validationService;
     this.transformer = new LegacyFormatTransformer(options);
   }
@@ -84,6 +94,7 @@ export class CoreDataService {
     return {
       objectService: this.objectService,
       queryService: this.queryService,
+      schemaService: this.schemaService,
       typeService: this.typeService,
       validationService: this.validationService,
     };
@@ -244,6 +255,7 @@ export default {
   CoreDataService,
   ObjectService,
   QueryService,
+  SchemaService,
   TypeService,
   ValidationService,
   LegacyFormatTransformer,

--- a/services/core-data-service/src/routes/v2/index.js
+++ b/services/core-data-service/src/routes/v2/index.js
@@ -14,12 +14,13 @@ import { Router } from 'express';
  * @param {ObjectService} services.objectService - Object service
  * @param {QueryService} services.queryService - Query service
  * @param {TypeService} services.typeService - Type service
+ * @param {SchemaService} services.schemaService - Schema introspection service
  * @param {Object} [options] - Route options
  * @returns {Router} Express router
  */
 export function createV2Routes(services, options = {}) {
   const router = Router();
-  const { objectService, queryService, typeService } = services;
+  const { objectService, queryService, typeService, schemaService, transactionService } = services;
   const logger = options.logger || console;
 
   // ============================================================================
@@ -114,15 +115,22 @@ export function createV2Routes(services, options = {}) {
     }
   });
 
-  // Get type schema (with requisites)
+  // Get type schema (with requisites) — delegated to SchemaService for richer output
+  // Includes requisites, relationships, and sample data.
+  // Original route used typeService.getSchema(); now uses schemaService.getTypeSchema().
   router.get('/databases/:database/types/:typeId/schema', async (req, res) => {
     try {
       const { database, typeId } = req.params;
 
-      const schema = await typeService.getSchema(database, parseInt(typeId, 10));
+      const schema = await schemaService.getTypeSchema(database, parseInt(typeId, 10));
+
+      if (!schema) {
+        return res.status(404).json(wrapError({ message: 'Type not found' }, 'NOT_FOUND'));
+      }
+
       res.json(wrapResponse(schema));
     } catch (error) {
-      logger.error('GET schema failed', { error: error.message });
+      logger.error('GET type schema failed', { error: error.message });
       if (error.name === 'NotFoundError') {
         return res.status(404).json(wrapError(error, 'NOT_FOUND'));
       }
@@ -464,6 +472,39 @@ export function createV2Routes(services, options = {}) {
       }));
     } catch (error) {
       logger.error('GET stats failed', { error: error.message });
+      res.status(500).json(wrapError(error));
+    }
+  });
+
+  // ============================================================================
+  // Schema Introspection Routes
+  // ============================================================================
+
+  // Get full database schema
+  router.get('/databases/:database/schema', async (req, res) => {
+    try {
+      const { database } = req.params;
+
+      const schema = await schemaService.getFullSchema(database);
+      res.json(wrapResponse(schema, {
+        totalTypes: schema.stats.totalTypes,
+        totalObjects: schema.stats.totalObjects,
+      }));
+    } catch (error) {
+      logger.error('GET schema failed', { error: error.message });
+      res.status(500).json(wrapError(error));
+    }
+  });
+
+  // Get relationship graph
+  router.get('/databases/:database/schema/relationships', async (req, res) => {
+    try {
+      const { database } = req.params;
+
+      const relationships = await schemaService.getRelationships(database);
+      res.json(wrapResponse(relationships, { count: relationships.length }));
+    } catch (error) {
+      logger.error('GET relationships failed', { error: error.message });
       res.status(500).json(wrapError(error));
     }
   });

--- a/services/core-data-service/src/services/SchemaService.js
+++ b/services/core-data-service/src/services/SchemaService.js
@@ -1,0 +1,350 @@
+/**
+ * @integram/core-data-service - SchemaService
+ *
+ * Provides schema introspection for Integram databases.
+ * Returns complete type definitions, requisites, relationships, and sample data.
+ */
+
+import {
+  BASIC_TYPES,
+} from '@integram/common';
+
+import { ValidationService } from './ValidationService.js';
+
+// ============================================================================
+// SchemaService Class
+// ============================================================================
+
+/**
+ * Service for introspecting Integram database schemas.
+ * Aggregates type, requisite, relationship, and sample data.
+ */
+export class SchemaService {
+  /**
+   * Create a new schema service.
+   *
+   * @param {Object} databaseService - Database service instance
+   * @param {Object} services - Related service instances
+   * @param {TypeService} services.typeService - Type service
+   * @param {QueryService} services.queryService - Query service
+   * @param {ObjectService} services.objectService - Object service
+   * @param {Object} [options] - Service options
+   * @param {Object} [options.logger] - Logger instance
+   * @param {number} [options.cacheTimeout] - Cache TTL in ms (default: 60000)
+   */
+  constructor(databaseService, services, options = {}) {
+    this.db = databaseService;
+    this.typeService = services.typeService;
+    this.queryService = services.queryService;
+    this.objectService = services.objectService;
+    this.logger = options.logger || console;
+    this.validation = options.validationService || new ValidationService(options);
+
+    // Schema cache with 60-second TTL
+    this._cache = new Map();
+    this._cacheTimeout = options.cacheTimeout || 60000;
+  }
+
+  // ============================================================================
+  // Cache Helpers
+  // ============================================================================
+
+  /**
+   * Get value from cache if still valid.
+   *
+   * @param {string} key - Cache key
+   * @returns {*|null} Cached value or null
+   */
+  _getCached(key) {
+    if (this._cache.has(key)) {
+      const entry = this._cache.get(key);
+      if (Date.now() - entry.timestamp < this._cacheTimeout) {
+        return entry.data;
+      }
+      this._cache.delete(key);
+    }
+    return null;
+  }
+
+  /**
+   * Set value in cache.
+   *
+   * @param {string} key - Cache key
+   * @param {*} data - Data to cache
+   */
+  _setCache(key, data) {
+    this._cache.set(key, {
+      data,
+      timestamp: Date.now(),
+    });
+  }
+
+  // ============================================================================
+  // Public API
+  // ============================================================================
+
+  /**
+   * Get full database schema: all types with requisites, counts, and relationships.
+   *
+   * @param {string} database - Database name
+   * @returns {Promise<Object>} Full schema object
+   */
+  async getFullSchema(database) {
+    const db = this.validation.validateDatabase(database);
+    const cacheKey = `fullSchema:${db}`;
+
+    const cached = this._getCached(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    // Get all types
+    const types = await this.typeService.getAllTypes(database, { includeSystem: false });
+
+    // Get object counts grouped by type
+    const typeCounts = await this.queryService.countByType(database);
+    const countMap = {};
+    let totalObjects = 0;
+    for (const entry of typeCounts) {
+      countMap[entry.t] = entry.count;
+      totalObjects += entry.count;
+    }
+
+    // Build type details with requisites
+    const typeDetails = [];
+    const allRelationships = [];
+
+    for (const type of types) {
+      const requisites = await this.typeService.getRequisites(database, type.id);
+
+      const mappedRequisites = requisites.map(req => {
+        const isRef = !this.typeService.isBasicType(req.typeId) && req.typeId !== type.id;
+
+        // Collect relationships
+        if (isRef) {
+          allRelationships.push({
+            fromType: type.id,
+            fromName: type.name,
+            toType: req.typeId,
+            toName: null, // resolved below
+            requisiteId: req.id,
+            alias: req.alias || req.name,
+          });
+        }
+
+        return {
+          id: req.id,
+          alias: req.alias || req.name,
+          type: req.typeId,
+          baseTypeName: BASIC_TYPES[req.typeId] || null,
+          refType: isRef ? req.typeId : null,
+          required: req.required,
+          multi: req.multi,
+        };
+      });
+
+      typeDetails.push({
+        id: type.id,
+        name: type.name,
+        baseType: type.baseType,
+        baseTypeName: BASIC_TYPES[type.baseType] || null,
+        count: countMap[type.id] || 0,
+        requisites: mappedRequisites,
+      });
+    }
+
+    // Resolve relationship target names
+    const typeNameMap = {};
+    for (const t of typeDetails) {
+      typeNameMap[t.id] = t.name;
+    }
+    for (const rel of allRelationships) {
+      rel.toName = typeNameMap[rel.toType] || null;
+    }
+
+    const result = {
+      types: typeDetails,
+      relationships: allRelationships,
+      stats: {
+        totalTypes: typeDetails.length,
+        totalObjects,
+      },
+    };
+
+    this._setCache(cacheKey, result);
+
+    return result;
+  }
+
+  /**
+   * Get schema for a single type with full detail and sample data.
+   *
+   * @param {string} database - Database name
+   * @param {number} typeId - Type ID
+   * @returns {Promise<Object>} Type schema with sample
+   */
+  async getTypeSchema(database, typeId) {
+    const db = this.validation.validateDatabase(database);
+    const tid = this.validation.validateTypeId(typeId);
+    const cacheKey = `typeSchema:${db}:${tid}`;
+
+    const cached = this._getCached(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    // Get type info
+    const type = await this.typeService.getType(database, tid);
+    if (!type) {
+      return null;
+    }
+
+    // Get requisites
+    const requisites = await this.typeService.getRequisites(database, tid);
+
+    // Get object count
+    const count = await this.typeService.getObjectCount(database, tid);
+
+    // Get sample data
+    const sample = await this.getSample(database, tid, 5);
+
+    // Build relationships for this type
+    const relationships = [];
+    const mappedRequisites = requisites.map(req => {
+      const isRef = !this.typeService.isBasicType(req.typeId) && req.typeId !== tid;
+
+      if (isRef) {
+        relationships.push({
+          fromType: tid,
+          fromName: type.name,
+          toType: req.typeId,
+          toName: null,
+          requisiteId: req.id,
+          alias: req.alias || req.name,
+        });
+      }
+
+      return {
+        id: req.id,
+        alias: req.alias || req.name,
+        type: req.typeId,
+        baseTypeName: BASIC_TYPES[req.typeId] || null,
+        refType: isRef ? req.typeId : null,
+        required: req.required,
+        multi: req.multi,
+      };
+    });
+
+    // Resolve target type names in relationships
+    for (const rel of relationships) {
+      const targetType = await this.typeService.getType(database, rel.toType);
+      rel.toName = targetType ? targetType.name : null;
+    }
+
+    const result = {
+      id: type.id,
+      name: type.name,
+      baseType: type.baseType,
+      baseTypeName: BASIC_TYPES[type.baseType] || null,
+      count,
+      requisites: mappedRequisites,
+      relationships,
+      sample,
+    };
+
+    this._setCache(cacheKey, result);
+
+    return result;
+  }
+
+  /**
+   * Get all reference relationships between types.
+   *
+   * @param {string} database - Database name
+   * @returns {Promise<Array>} Array of relationship objects
+   */
+  async getRelationships(database) {
+    const db = this.validation.validateDatabase(database);
+    const cacheKey = `relationships:${db}`;
+
+    const cached = this._getCached(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const types = await this.typeService.getAllTypes(database, { includeSystem: false });
+
+    // Build name map
+    const typeNameMap = {};
+    for (const t of types) {
+      typeNameMap[t.id] = t.name;
+    }
+
+    const relationships = [];
+
+    for (const type of types) {
+      const requisites = await this.typeService.getRequisites(database, type.id);
+
+      for (const req of requisites) {
+        const isRef = !this.typeService.isBasicType(req.typeId) && req.typeId !== type.id;
+        if (isRef) {
+          relationships.push({
+            fromType: type.id,
+            fromName: type.name,
+            toType: req.typeId,
+            toName: typeNameMap[req.typeId] || null,
+            requisiteId: req.id,
+            alias: req.alias || req.name,
+          });
+        }
+      }
+    }
+
+    this._setCache(cacheKey, relationships);
+
+    return relationships;
+  }
+
+  /**
+   * Get sample rows for a type with requisite values.
+   *
+   * @param {string} database - Database name
+   * @param {number} typeId - Type ID
+   * @param {number} [limit=5] - Number of sample rows
+   * @returns {Promise<Array>} Sample objects with requisites
+   */
+  async getSample(database, typeId, limit = 5) {
+    const db = this.validation.validateDatabase(database);
+    const tid = this.validation.validateTypeId(typeId);
+
+    const objects = await this.queryService.queryObjects(database, {
+      typeId: tid,
+      limit,
+      orderBy: 'id',
+      sortDir: 'ASC',
+    });
+
+    if (objects.length === 0) {
+      return [];
+    }
+
+    // Get requisites for each sample object
+    const samples = [];
+    for (const obj of objects) {
+      const requisites = await this.objectService.getRequisites(database, obj.id);
+      samples.push({
+        id: obj.id,
+        value: obj.val,
+        requisites,
+      });
+    }
+
+    return samples;
+  }
+}
+
+// ============================================================================
+// Export
+// ============================================================================
+
+export default SchemaService;

--- a/services/core-data-service/src/services/index.js
+++ b/services/core-data-service/src/services/index.js
@@ -6,17 +6,29 @@
 
 export { ObjectService } from './ObjectService.js';
 export { QueryService } from './QueryService.js';
+export { SchemaService } from './SchemaService.js';
 export { TypeService } from './TypeService.js';
 export { ValidationService } from './ValidationService.js';
+export { TransactionService, TRANSACTION_ACTIONS } from './TransactionService.js';
+export { AuditService } from './AuditService.js';
+export { OntologyService } from './OntologyService.js';
 
 export default {
   ObjectService,
   QueryService,
+  SchemaService,
   TypeService,
   ValidationService,
+  TransactionService,
+  AuditService,
+  OntologyService,
 };
 
 import { ObjectService } from './ObjectService.js';
 import { QueryService } from './QueryService.js';
+import { SchemaService } from './SchemaService.js';
 import { TypeService } from './TypeService.js';
 import { ValidationService } from './ValidationService.js';
+import { TransactionService } from './TransactionService.js';
+import { AuditService } from './AuditService.js';
+import { OntologyService } from './OntologyService.js';


### PR DESCRIPTION
## Summary
- New **SchemaService** with `getFullSchema()`, `getTypeSchema()`, `getRelationships()`, and `getSample()` methods, all with 60-second caching
- New V2 routes: `GET /databases/:db/schema` (full schema) and `GET /databases/:db/schema/relationships` (relationship graph)
- Upgraded existing `GET /databases/:db/types/:typeId/schema` to return richer output including relationships and sample data
- Wired SchemaService into CoreDataService and getServices()

## Response format
`GET /databases/:db/schema` returns `{ types, relationships, stats }` with requisite details, reference types, and object counts per type.

## Test plan
- [ ] Verify `GET /v2/databases/{db}/schema` returns complete schema with types, requisites, relationships, and stats
- [ ] Verify `GET /v2/databases/{db}/types/{id}/schema` returns type detail with sample rows
- [ ] Verify `GET /v2/databases/{db}/schema/relationships` returns reference edges
- [ ] Verify caching works (second request within 60s is faster)
- [ ] Verify 404 for non-existent type ID on type schema endpoint

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)