### PR TITLE
feat: Schema Introspection API

### DIFF
--- a/services/core-data-service/src/routes/v2/index.js
+++ b/services/core-data-service/src/routes/v2/index.js
@@ -6,6 +6,7 @@
  */
 
 import { Router } from 'express';
+import { createSchemaRoutes } from './schema.js';
 
 /**
  * Create V2 modern routes.
@@ -508,6 +509,15 @@ export function createV2Routes(services, options = {}) {
       res.status(500).json(wrapError(error));
     }
   });
+
+  // ==========================================================================
+  // Schema Introspection Routes — выделенный модуль (stats, export, types)
+  // ==========================================================================
+
+  if (schemaService) {
+    const schemaRoutes = createSchemaRoutes({ schemaService }, options);
+    router.use('/databases/:database/schema', schemaRoutes);
+  }
 
   return router;
 }

--- a/services/core-data-service/src/routes/v2/schema.js
+++ b/services/core-data-service/src/routes/v2/schema.js
@@ -1,0 +1,121 @@
+/**
+ * @integram/core-data-service — V2 Schema Introspection Routes
+ *
+ * Роуты для интроспекции схемы базы данных Integram.
+ * Предоставляет полную схему, связи, статистику и экспорт в JSON Schema / OpenAPI.
+ */
+
+import { Router } from 'express';
+
+/**
+ * Создать роуты для интроспекции схемы.
+ *
+ * @param {Object} services - Экземпляры сервисов
+ * @param {SchemaService} services.schemaService - Сервис интроспекции схемы
+ * @param {Object} [options] - Настройки роутов
+ * @returns {Router} Express router
+ */
+export function createSchemaRoutes(services, options = {}) {
+  const router = Router({ mergeParams: true });
+  const { schemaService } = services;
+  const logger = options.logger || console;
+
+  /** Обёртка успешного ответа */
+  const wrapResponse = (data, meta = {}) => ({
+    success: true,
+    data,
+    meta: { timestamp: new Date().toISOString(), ...meta },
+  });
+
+  /** Обёртка ошибки */
+  const wrapError = (error, code = 'ERROR') => ({
+    success: false,
+    error: { code, message: error.message || 'Unknown error' },
+    meta: { timestamp: new Date().toISOString() },
+  });
+
+  // GET /schema — полная схема базы данных
+  router.get('/', async (req, res) => {
+    try {
+      const { database } = req.params;
+      const schema = await schemaService.getFullSchema(database);
+      res.json(wrapResponse(schema, {
+        totalTypes: schema.stats.totalTypes,
+        totalObjects: schema.stats.totalObjects,
+      }));
+    } catch (error) {
+      logger.error('GET schema failed', { error: error.message });
+      res.status(500).json(wrapError(error));
+    }
+  });
+
+  // GET /schema/types/:typeId — схема конкретной таблицы
+  router.get('/types/:typeId', async (req, res) => {
+    try {
+      const { database, typeId } = req.params;
+      const schema = await schemaService.getTableSchema(database, parseInt(typeId, 10));
+      if (!schema) {
+        return res.status(404).json(wrapError({ message: 'Type not found' }, 'NOT_FOUND'));
+      }
+      res.json(wrapResponse(schema));
+    } catch (error) {
+      logger.error('GET type schema failed', { error: error.message });
+      if (error.name === 'NotFoundError') {
+        return res.status(404).json(wrapError(error, 'NOT_FOUND'));
+      }
+      res.status(500).json(wrapError(error));
+    }
+  });
+
+  // GET /schema/relationships — граф связей между таблицами
+  router.get('/relationships', async (req, res) => {
+    try {
+      const { database } = req.params;
+      const relationships = await schemaService.getRelationships(database);
+      res.json(wrapResponse(relationships, { count: relationships.length }));
+    } catch (error) {
+      logger.error('GET relationships failed', { error: error.message });
+      res.status(500).json(wrapError(error));
+    }
+  });
+
+  // GET /schema/stats — статистика базы данных
+  router.get('/stats', async (req, res) => {
+    try {
+      const { database } = req.params;
+      const stats = await schemaService.getStats(database);
+      res.json(wrapResponse(stats));
+    } catch (error) {
+      logger.error('GET stats failed', { error: error.message });
+      res.status(500).json(wrapError(error));
+    }
+  });
+
+  // GET /schema/export/json-schema — экспорт в JSON Schema формат
+  router.get('/export/json-schema', async (req, res) => {
+    try {
+      const { database } = req.params;
+      const jsonSchema = await schemaService.exportJsonSchema(database);
+      res.json(wrapResponse(jsonSchema));
+    } catch (error) {
+      logger.error('GET json-schema export failed', { error: error.message });
+      res.status(500).json(wrapError(error));
+    }
+  });
+
+  // GET /schema/export/openapi — генерация OpenAPI спецификации
+  router.get('/export/openapi', async (req, res) => {
+    try {
+      const { database } = req.params;
+      const openapi = await schemaService.exportOpenAPI(database);
+      res.json(wrapResponse(openapi));
+    } catch (error) {
+      logger.error('GET openapi export failed', { error: error.message });
+      res.status(500).json(wrapError(error));
+    }
+  });
+
+  return router;
+}
+
+export default createSchemaRoutes;

--- a/services/core-data-service/src/services/SchemaService.js
+++ b/services/core-data-service/src/services/SchemaService.js
@@ -306,6 +306,280 @@ export class SchemaService {
   }
 
   /**
+   * Алиас для getTypeSchema — схема конкретной таблицы с реквизитами.
+   *
+   * @param {string} database - Имя базы данных
+   * @param {number} typeId - ID типа (таблицы)
+   * @returns {Promise<Object|null>} Схема таблицы
+   */
+  async getTableSchema(database, typeId) {
+    return this.getTypeSchema(database, typeId);
+  }
+
+  /**
+   * Статистика базы данных: количество записей по типам, общий объём.
+   *
+   * @param {string} database - Имя базы данных
+   * @returns {Promise<Object>} Объект статистики
+   */
+  async getStats(database) {
+    const db = this.validation.validateDatabase(database);
+    const cacheKey = `stats:${db}`;
+    const cached = this._getCached(cacheKey);
+    if (cached) return cached;
+
+    const types = await this.typeService.getAllTypes(database, { includeSystem: false });
+    const typeCounts = await this.queryService.countByType(database);
+    const countMap = {};
+    let totalObjects = 0;
+    for (const entry of typeCounts) {
+      countMap[entry.t] = entry.count;
+      totalObjects += entry.count;
+    }
+
+    // Собираем статистику по каждому типу
+    const byType = [];
+    for (const type of types) {
+      const count = countMap[type.id] || 0;
+      const requisites = await this.typeService.getRequisites(database, type.id);
+      byType.push({
+        id: type.id,
+        name: type.name,
+        objectCount: count,
+        requisiteCount: requisites.length,
+      });
+    }
+
+    // Сортируем по количеству объектов (убывание)
+    byType.sort((a, b) => b.objectCount - a.objectCount);
+
+    const result = {
+      database: db,
+      totalTypes: types.length,
+      totalObjects,
+      totalRequisites: byType.reduce((sum, t) => sum + t.requisiteCount, 0),
+      byType,
+    };
+    this._setCache(cacheKey, result);
+    return result;
+  }
+
+  /**
+   * Экспорт схемы базы данных в формат JSON Schema (draft-07).
+   *
+   * @param {string} database - Имя базы данных
+   * @returns {Promise<Object>} JSON Schema объект
+   */
+  async exportJsonSchema(database) {
+    const db = this.validation.validateDatabase(database);
+    const cacheKey = `jsonSchema:${db}`;
+    const cached = this._getCached(cacheKey);
+    if (cached) return cached;
+
+    const fullSchema = await this.getFullSchema(database);
+
+    // Маппинг базовых типов Integram в JSON Schema типы
+    const typeMapping = {
+      SHORT: { type: 'string', maxLength: 255 },
+      CHARS: { type: 'string' },
+      DATE: { type: 'string', format: 'date' },
+      NUMBER: { type: 'number' },
+      SIGNED: { type: 'integer' },
+      BOOLEAN: { type: 'boolean' },
+      MEMO: { type: 'string', maxLength: 65535 },
+      DATETIME: { type: 'string', format: 'date-time' },
+      FILE: { type: 'string', description: 'Путь к файлу' },
+      HTML: { type: 'string', contentMediaType: 'text/html' },
+      BUTTON: { type: 'string' },
+      PWD: { type: 'string', writeOnly: true },
+      GRANT: { type: 'string' },
+      CALCULATABLE: { type: 'string', readOnly: true },
+      REPORT_COLUMN: { type: 'string' },
+      PATH: { type: 'string' },
+    };
+
+    const definitions = {};
+    for (const typeDetail of fullSchema.types) {
+      const properties = {
+        id: { type: 'integer', description: 'Уникальный идентификатор объекта' },
+        value: { type: 'string', description: 'Основное значение объекта' },
+        parentId: { type: 'integer', description: 'ID родительского объекта' },
+      };
+      const required = ['id', 'value'];
+
+      for (const req of typeDetail.requisites) {
+        const baseName = req.baseTypeName;
+        const mapped = typeMapping[baseName] || { type: 'string' };
+
+        if (req.refType) {
+          // Ссылочный реквизит — reference на другой тип
+          const refTypeName = fullSchema.types.find(t => t.id === req.refType)?.name;
+          properties[req.alias] = {
+            $ref: refTypeName ? `#/definitions/${refTypeName}` : undefined,
+            description: `Ссылка на ${refTypeName || req.refType}`,
+            type: 'integer',
+          };
+        } else {
+          properties[req.alias] = { ...mapped };
+        }
+
+        // Мультизначные реквизиты оборачиваем в массив
+        if (req.multi) {
+          properties[req.alias] = {
+            type: 'array',
+            items: properties[req.alias],
+          };
+        }
+
+        if (req.required) {
+          required.push(req.alias);
+        }
+      }
+
+      definitions[typeDetail.name] = {
+        type: 'object',
+        title: typeDetail.name,
+        properties,
+        required,
+      };
+    }
+
+    const result = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      title: `Integram Database: ${db}`,
+      description: `Автоматически сгенерированная JSON Schema для базы данных ${db}`,
+      definitions,
+    };
+    this._setCache(cacheKey, result);
+    return result;
+  }
+
+  /**
+   * Генерация OpenAPI 3.0 спецификации для данной БД.
+   *
+   * @param {string} database - Имя базы данных
+   * @returns {Promise<Object>} OpenAPI спецификация
+   */
+  async exportOpenAPI(database) {
+    const db = this.validation.validateDatabase(database);
+    const cacheKey = `openapi:${db}`;
+    const cached = this._getCached(cacheKey);
+    if (cached) return cached;
+
+    const jsonSchema = await this.exportJsonSchema(database);
+    const fullSchema = await this.getFullSchema(database);
+
+    // Конвертируем definitions в OpenAPI components/schemas
+    const schemas = {};
+    for (const [name, def] of Object.entries(jsonSchema.definitions || {})) {
+      const schemaCopy = { ...def };
+      if (schemaCopy.properties) {
+        for (const [propName, propDef] of Object.entries(schemaCopy.properties)) {
+          if (propDef.$ref) {
+            schemaCopy.properties[propName] = {
+              ...propDef,
+              $ref: propDef.$ref.replace('#/definitions/', '#/components/schemas/'),
+            };
+          }
+          if (propDef.items && propDef.items.$ref) {
+            schemaCopy.properties[propName] = {
+              ...propDef,
+              items: {
+                ...propDef.items,
+                $ref: propDef.items.$ref.replace('#/definitions/', '#/components/schemas/'),
+              },
+            };
+          }
+        }
+      }
+      schemas[name] = schemaCopy;
+    }
+
+    // Генерируем пути API для каждого типа
+    const paths = {};
+    for (const typeDetail of fullSchema.types) {
+      const typeName = typeDetail.name;
+      const basePath = `/api/v2/${db}/types/${typeDetail.id}/objects`;
+
+      // GET — список объектов данного типа
+      paths[basePath] = {
+        get: {
+          summary: `Список объектов типа "${typeName}"`,
+          tags: [typeName],
+          parameters: [
+            { name: 'limit', in: 'query', schema: { type: 'integer', default: 20 } },
+            { name: 'offset', in: 'query', schema: { type: 'integer', default: 0 } },
+            { name: 'parentId', in: 'query', schema: { type: 'integer' } },
+          ],
+          responses: {
+            200: {
+              description: 'Успешный ответ',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      success: { type: 'boolean' },
+                      data: {
+                        type: 'array',
+                        items: { $ref: `#/components/schemas/${typeName}` },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      // GET по ID — получение конкретного объекта
+      paths[`${basePath}/{objectId}`] = {
+        get: {
+          summary: `Получить объект типа "${typeName}" по ID`,
+          tags: [typeName],
+          parameters: [
+            { name: 'objectId', in: 'path', required: true, schema: { type: 'integer' } },
+          ],
+          responses: {
+            200: {
+              description: 'Успешный ответ',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      success: { type: 'boolean' },
+                      data: { $ref: `#/components/schemas/${typeName}` },
+                    },
+                  },
+                },
+              },
+            },
+            404: { description: 'Объект не найден' },
+          },
+        },
+      };
+    }
+
+    const result = {
+      openapi: '3.0.3',
+      info: {
+        title: `Integram API — ${db}`,
+        description: `Автоматически сгенерированная OpenAPI спецификация для базы данных ${db}`,
+        version: '2.0.0',
+      },
+      servers: [
+        { url: '/api/v2', description: 'V2 JSON:API' },
+      ],
+      paths,
+      components: { schemas },
+    };
+    this._setCache(cacheKey, result);
+    return result;
+  }
+
+  /**
    * Get sample rows for a type with requisite values.
    *
    * @param {string} database - Database name


### PR DESCRIPTION
## Summary

Closes #183

- Расширяет `SchemaService` методами `getTableSchema`, `getStats`, `exportJsonSchema`, `exportOpenAPI`
- Создаёт выделенный модуль роутов `schema.js` с 6 эндпоинтами интроспекции схемы
- Регистрирует роуты в `v2/index.js` через `createSchemaRoutes`

### API endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v2/:db/schema` | Полная схема БД |
| GET | `/api/v2/:db/schema/types/:typeId` | Схема таблицы |
| GET | `/api/v2/:db/schema/relationships` | Граф связей |
| GET | `/api/v2/:db/schema/stats` | Статистика |
| GET | `/api/v2/:db/schema/export/json-schema` | JSON Schema экспорт |
| GET | `/api/v2/:db/schema/export/openapi` | OpenAPI спецификация |

## Test plan

- [ ] Проверить GET /schema возвращает полную схему с types, relationships, stats
- [ ] Проверить GET /schema/types/:typeId возвращает схему таблицы с sample
- [ ] Проверить GET /schema/stats возвращает byType с objectCount/requisiteCount
- [ ] Проверить GET /schema/export/json-schema генерирует валидный draft-07
- [ ] Проверить GET /schema/export/openapi генерирует валидный OpenAPI 3.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)