### PR TITLE
fix: V2 API auth routing — skip /api/v2/* in legacy router

### DIFF
--- a/backend/monolith/scripts/start.js
+++ b/backend/monolith/scripts/start.js
@@ -74,6 +74,88 @@ if (fs.existsSync(PUBLIC_PATH)) {
   console.log(`   App UI: http://localhost:${PORT}/app/templates/login.html`);
 }
 
+// ── API v2 auth endpoint (handles POST /api/v2/auth) ────────────────────────
+// Mounted BEFORE legacy router to prevent /:db/auth from intercepting v2 paths.
+// Proxies auth to legacy /:db/auth?JSON internally.
+
+app.post('/api/v2/auth', async (req, res) => {
+  try {
+    // Accept both JSON:API format and simple {login, password, database} format
+    let login, password, database;
+
+    if (req.body?.data?.type === 'auth') {
+      // JSON:API format
+      ({ login, password, database } = req.body.data.attributes || {});
+    } else {
+      // Simple format
+      ({ login, password, database } = req.body || {});
+    }
+
+    database = database || 'my';
+
+    if (!login || !password) {
+      return res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: 'login and password are required' }
+      });
+    }
+
+    // Use internal fetch to legacy auth endpoint
+    const legacyUrl = `http://127.0.0.1:${PORT}/${database}/auth?JSON`;
+    const formData = new URLSearchParams({ login, pwd: password });
+
+    const response = await fetch(legacyUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formData.toString()
+    });
+
+    const data = await response.json();
+
+    // Legacy auth returns {token, id, _xsrf, msg} on success
+    // or [{error: "..."}] on failure
+    if (Array.isArray(data) && data[0]?.error) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 'AUTH_FAILED', message: data[0].error }
+      });
+    }
+
+    if (data.token) {
+      return res.json({
+        success: true,
+        data: {
+          type: 'auth-session',
+          id: data.token,
+          attributes: {
+            token: data.token,
+            userId: data.id,
+            database,
+            xsrf: data._xsrf
+          }
+        },
+        meta: { timestamp: new Date().toISOString() }
+      });
+    }
+
+    // Unexpected response
+    return res.status(500).json({
+      success: false,
+      error: { code: 'UNEXPECTED', message: 'Unexpected auth response' },
+      meta: { legacy: data }
+    });
+
+  } catch (err) {
+    console.error('[V2 Auth] Error:', err.message);
+    return res.status(500).json({
+      success: false,
+      error: { code: 'AUTH_ERROR', message: err.message }
+    });
+  }
+});
+
+console.log('   API v2 auth: POST /api/v2/auth');
+
 // ── Legacy PHP-compatible API + page routing ──────────────────────────────────
 
 const { default: legacyRouter } = await import('../src/api/routes/legacy-compat.js');

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -22,6 +22,16 @@ const router = express.Router();
 // This middleware ensures all JSON responses have keys sorted alphabetically.
 router.use(phpJsonMiddleware());
 
+// Skip API v2 paths — let them fall through to the V2 router mounted in start.js.
+// Without this, the legacy /:db/auth and /:db POST handlers intercept
+// /api/v2/auth (where db="v2") and fail with "v2 does not exist".
+router.use((req, res, next) => {
+  if (req.path.startsWith('/v2/') || req.path === '/v2') {
+    return next('router');
+  }
+  next();
+});
+
 // Get the directory path for serving static files
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);


### PR DESCRIPTION
## Summary
- **start.js**: Add `POST /api/v2/auth` handler before the legacy router. Proxies auth to legacy `/:db/auth?JSON` internally and returns V2-format JSON.
- **legacy-compat.js**: Add middleware to skip `/v2/*` paths with `next('router')`, preventing `/:db/auth` and `/:db` POST handlers from treating `"v2"` as a database name.

## Problem
`POST https://api.ai2o.ru/api/v2/auth` fails with `[{"error":"v2 does not exist"}]` because:
1. The legacy router is mounted at `/api` in start.js
2. The POST `/:db/auth` handler matches with `db="v2"`
3. The GET handler has skip logic for `api` prefix but POST handlers do not
4. The legacy auth tries to query a MySQL table named `v2` which does not exist

## Test plan
- [ ] `curl -s -X POST https://api.ai2o.ru/api/v2/auth -H 'Content-Type: application/json' -d '{"login":"d","password":"d"}'` returns auth token
- [ ] `curl -s https://api.ai2o.ru/api/v2/databases/kval/schema/stats` still works
- [ ] Legacy auth `POST /my/auth?JSON` still works
- [ ] PM2 restart: `pm2 restart 7`

Generated with [Claude Code](https://claude.com/claude-code)