### PR TITLE
feat: Phase 2 — wire middleware into route signatures

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
+++ b/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
@@ -817,3 +817,104 @@ describe('checkNewRef', () => {
     expect(result).toBe(false);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 2 — Middleware Wiring Integration Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Phase 2: middleware wiring', () => {
+  const app = makeApp();
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('DML routes reject unauthenticated requests', () => {
+    const dmlRoutes = [
+      ['_m_new/1', 'POST'],
+      ['_m_save/1', 'POST'],
+      ['_m_del/1', 'POST'],
+      ['_m_set/1', 'POST'],
+      ['_m_move/1', 'POST'],
+      ['_m_up/1', 'POST'],
+      ['_m_ord/1', 'POST'],
+      ['_m_id/1', 'POST'],
+    ];
+
+    for (const [route, method] of dmlRoutes) {
+      it(`POST /${DB}/${route} → 401 without token`, async () => {
+        const res = await request(app)
+          .post(`/${DB}/${route}`)
+          .send({ _xsrf: 'fake' });
+        expect(res.status).toBe(401);
+        expect(res.body.error).toBeDefined();
+      });
+    }
+  });
+
+  describe('DML routes reject invalid XSRF', () => {
+    const token = 'dml-token';
+    const xsrf = generateXsrf(token, DB, DB);
+
+    it('POST _m_save with wrong XSRF → error (HTTP 200)', async () => {
+      // Auth middleware: token lookup returns user
+      mockQuery(
+        [[{ uid: 1, uname: 'alice', xsrf_val: xsrf, role_val: 'Manager', roleId: 7 }]],
+        [[]], // grants
+      );
+
+      const res = await request(app)
+        .post(`/${DB}/_m_save/1`)
+        .set('Cookie', `${DB}=${token}`)
+        .send({ _xsrf: 'wrong-xsrf', val: 'test' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([{ error: 'Invalid or expired CSRF token' }]);
+    });
+  });
+
+  describe('DDL routes reject unauthenticated requests', () => {
+    const ddlRoutes = [
+      '_d_new', '_d_save/1', '_d_del/1', '_d_req/1',
+      '_d_alias/1', '_d_null/1', '_d_multi/1', '_d_attrs/1',
+      '_d_up/1', '_d_ord/1', '_d_del_req/1', '_d_ref/1',
+    ];
+
+    for (const route of ddlRoutes) {
+      it(`POST /${DB}/${route} → 401 without token`, async () => {
+        const res = await request(app)
+          .post(`/${DB}/${route}`)
+          .send({ _xsrf: 'fake' });
+        expect(res.status).toBe(401);
+        expect(res.body.error).toBeDefined();
+      });
+    }
+  });
+
+  describe('Query routes reject unauthenticated requests', () => {
+    const queryRoutes = [
+      ['terms', 'GET'],
+      ['_ref_reqs/1', 'GET'],
+      ['_connect', 'GET'],
+      ['obj_meta/1', 'GET'],
+      ['metadata', 'GET'],
+    ];
+
+    for (const [route, method] of queryRoutes) {
+      it(`GET /${DB}/${route} → 401 without token`, async () => {
+        const res = await request(app)
+          .get(`/${DB}/${route}`);
+        expect(res.status).toBe(401);
+        expect(res.body.error).toBeDefined();
+      });
+    }
+  });
+
+  describe('xsrf route still works without middleware', () => {
+    it('GET /:db/xsrf → 200 with empty session (no token)', async () => {
+      const res = await request(app)
+        .get(`/${DB}/xsrf`);
+      // xsrf route should return 200 with empty session (no 401)
+      expect(res.status).toBe(200);
+      expect(res.body._xsrf).toBe('');
+    });
+  });
+});

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -3649,7 +3649,7 @@ async function getRequisiteByType(db, parentId, typeId) {
  * Parameters: up (parent ID), t (type ID), val, t{id}=value (attributes)
  * Supports file uploads for FILE-type requisites (multer memoryStorage).
  */
-router.post('/:db/_m_new/:up?', (req, res, next) => {
+router.post('/:db/_m_new/:up?', legacyAuthMiddleware, legacyXsrfCheck, (req, res, next) => {
   // Use upload.any() so FILE-type requisites can be uploaded alongside text fields
   upload.any()(req, res, (err) => {
     if (err) logger.warn('[Legacy _m_new] Multer error', { error: err.message });
@@ -3756,7 +3756,7 @@ router.post('/:db/_m_new/:up?', (req, res, next) => {
  * PHP: index.php lines 7991-8163
  * When copybtn is set, copies the object and all its requisites.
  */
-router.post('/:db/_m_save/:id', async (req, res) => {
+router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req, res) => {
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
@@ -4004,7 +4004,7 @@ router.post('/:db/_m_save/:id', async (req, res) => {
  * _m_del - Delete object
  * POST /:db/_m_del/:id
  */
-router.post('/:db/_m_del/:id', async (req, res) => {
+router.post('/:db/_m_del/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req, res) => {
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
@@ -4098,7 +4098,7 @@ router.post('/:db/_m_del/:id', async (req, res) => {
  * Parameters: t{id}=value (attributes to set), or t{id}=<file> for inline file upload
  * saveInlineFile in smartq.js uploads file as t{reqId} and reads json.args as download path
  */
-router.post('/:db/_m_set/:id', upload.any(), async (req, res) => {
+router.post('/:db/_m_set/:id', legacyAuthMiddleware, legacyXsrfCheck, upload.any(), async (req, res) => {
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
@@ -4180,7 +4180,7 @@ router.post('/:db/_m_set/:id', upload.any(), async (req, res) => {
  * POST /:db/_m_move/:id
  * Parameters: up (new parent ID)
  */
-router.post('/:db/_m_move/:id', async (req, res) => {
+router.post('/:db/_m_move/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req, res) => {
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
@@ -4641,7 +4641,7 @@ router.all('/:db/_d_main/:typeId', async (req, res) => {
  * PHP filters types through Grant_1level($id) — shows only those the user has access to.
  * Node.js now replicates this behavior using the grant1Level function.
  */
-router.get('/:db/terms', async (req, res) => {
+router.get('/:db/terms', legacyAuthMiddleware, async (req, res) => {
   const { db } = req.params;
 
   if (!isValidDbName(db)) {
@@ -4809,7 +4809,7 @@ router.get('/:db/xsrf', async (req, res) => {
  *   ?r=<id> - Restrict to specific ID
  *   ?r=<id1>,<id2> - Restrict to multiple IDs
  */
-router.get('/:db/_ref_reqs/:refId', async (req, res) => {
+router.get('/:db/_ref_reqs/:refId', legacyAuthMiddleware, async (req, res) => {
   const { db, refId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5045,7 +5045,7 @@ router.get('/:db/_ref_reqs/:refId', async (req, res) => {
  * _connect - Check database connection (or proxy to CONNECT requisite URL if id given)
  * GET/POST /:db/_connect[/:id]
  */
-router.all('/:db/_connect/:id?', async (req, res) => {
+router.all('/:db/_connect/:id?', legacyAuthMiddleware, async (req, res) => {
   const { db, id: idParam } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5146,7 +5146,7 @@ function buildModifiers(name, alias, required, multi) {
  * POST /:db/_d_new/:parentTypeId?
  * Parameters: val (type name), t (base type), parentTypeId (optional parent)
  */
-router.post('/:db/_d_new/:parentTypeId?', async (req, res) => {
+router.post('/:db/_d_new/:parentTypeId?', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, parentTypeId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5189,7 +5189,7 @@ router.post('/:db/_d_new/:parentTypeId?', async (req, res) => {
  * POST /:db/_d_save/:typeId
  * Parameters: val (new name), t (new base type)
  */
-router.post('/:db/_d_save/:typeId', async (req, res) => {
+router.post('/:db/_d_save/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5237,7 +5237,7 @@ router.post('/:db/_d_save/:typeId', async (req, res) => {
  * _d_del - Delete type
  * POST /:db/_d_del/:typeId
  */
-router.post('/:db/_d_del/:typeId', async (req, res) => {
+router.post('/:db/_d_del/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5273,7 +5273,7 @@ router.post('/:db/_d_del/:typeId', async (req, res) => {
  * POST /:db/_d_req/:typeId
  * Parameters: val (requisite name), t (requisite type), alias, required, multi
  */
-router.post('/:db/_d_req/:typeId', async (req, res) => {
+router.post('/:db/_d_req/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5316,7 +5316,7 @@ router.post('/:db/_d_req/:typeId', async (req, res) => {
  * POST /:db/_d_alias/:reqId
  * Parameters: alias (new alias value)
  */
-router.post('/:db/_d_alias/:reqId', async (req, res) => {
+router.post('/:db/_d_alias/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5358,7 +5358,7 @@ router.post('/:db/_d_alias/:reqId', async (req, res) => {
  * POST /:db/_d_null/:reqId
  * Parameters: required (1/0 or true/false)
  */
-router.post('/:db/_d_null/:reqId', async (req, res) => {
+router.post('/:db/_d_null/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5404,7 +5404,7 @@ router.post('/:db/_d_null/:reqId', async (req, res) => {
  * POST /:db/_d_multi/:reqId
  * Parameters: multi (1/0 or true/false)
  */
-router.post('/:db/_d_multi/:reqId', async (req, res) => {
+router.post('/:db/_d_multi/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5450,7 +5450,7 @@ router.post('/:db/_d_multi/:reqId', async (req, res) => {
  * POST /:db/_d_attrs/:reqId
  * Parameters: alias, required, multi (sets all modifiers at once)
  */
-router.post('/:db/_d_attrs/:reqId', async (req, res) => {
+router.post('/:db/_d_attrs/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5502,7 +5502,7 @@ router.post('/:db/_d_attrs/:reqId', async (req, res) => {
  * _d_up - Move requisite up (decrease order)
  * POST /:db/_d_up/:reqId
  */
-router.post('/:db/_d_up/:reqId', async (req, res) => {
+router.post('/:db/_d_up/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5553,7 +5553,7 @@ router.post('/:db/_d_up/:reqId', async (req, res) => {
  * POST /:db/_d_ord/:reqId
  * Parameters: order (new order value) — PHP uses $_REQUEST["order"] not "ord"
  */
-router.post('/:db/_d_ord/:reqId', async (req, res) => {
+router.post('/:db/_d_ord/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5612,7 +5612,7 @@ router.post('/:db/_d_ord/:reqId', async (req, res) => {
  * _d_del_req - Delete requisite
  * POST /:db/_d_del_req/:reqId
  */
-router.post('/:db/_d_del_req/:reqId', async (req, res) => {
+router.post('/:db/_d_del_req/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5654,7 +5654,7 @@ router.post('/:db/_d_del_req/:reqId', async (req, res) => {
  * PHP line 8649: SELECT ref.id FROM obj LEFT JOIN ref ON ref.up=0 AND ref.t=$id AND ref.val=''
  * PHP line 8661: Insert(0, 0, $id, "", "Create Ref") — up=0, ord=0, t=$id, val=""
  */
-router.post('/:db/_d_ref/:typeId', async (req, res) => {
+router.post('/:db/_d_ref/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacyDdlGrantCheck, async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5712,7 +5712,7 @@ router.post('/:db/_d_ref/:typeId', async (req, res) => {
  * _m_up - Move object up (decrease order)
  * POST /:db/_m_up/:id
  */
-router.post('/:db/_m_up/:id', async (req, res) => {
+router.post('/:db/_m_up/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req, res) => {
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5763,7 +5763,7 @@ router.post('/:db/_m_up/:id', async (req, res) => {
  * POST /:db/_m_ord/:id
  * Parameters: order (new order value, in query string: ?JSON&order=N)
  */
-router.post('/:db/_m_ord/:id', async (req, res) => {
+router.post('/:db/_m_ord/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req, res) => {
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5832,7 +5832,7 @@ router.post('/:db/_m_ord/:id', async (req, res) => {
  * _m_id - Change object ID (reserved operation)
  * POST /:db/_m_id/:id
  */
-router.post('/:db/_m_id/:id', async (req, res) => {
+router.post('/:db/_m_id/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req, res) => {
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5892,7 +5892,7 @@ router.post('/:db/_m_id/:id', async (req, res) => {
  * obj_meta - Get object metadata with requisites
  * GET/POST /:db/obj_meta/:id
  */
-router.all('/:db/obj_meta/:id', async (req, res) => {
+router.all('/:db/obj_meta/:id', legacyAuthMiddleware, async (req, res) => {
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
@@ -5974,7 +5974,7 @@ router.all('/:db/obj_meta/:id', async (req, res) => {
  * metadata - Get type/term metadata for all or specific type
  * GET/POST /:db/metadata/:typeId?
  */
-router.all('/:db/metadata/:typeId?', async (req, res) => {
+router.all('/:db/metadata/:typeId?', legacyAuthMiddleware, async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {


### PR DESCRIPTION
## Summary

Implements Phase 2 of PHP parity (#200): wires the Phase 1 middleware functions into all 25 route handler signatures.

### Routes modified

**DML routes (8)** — `legacyAuthMiddleware` + `legacyXsrfCheck`:
- `_m_new`, `_m_save`, `_m_del`, `_m_set`, `_m_move`, `_m_up`, `_m_ord`, `_m_id`

**DDL routes (12)** — `legacyAuthMiddleware` + `legacyXsrfCheck` + `legacyDdlGrantCheck`:
- `_d_new`, `_d_save`, `_d_del`, `_d_req`, `_d_alias`, `_d_null`, `_d_multi`, `_d_attrs`, `_d_up`, `_d_ord`, `_d_del_req`, `_d_ref`

**Query routes (5)** — `legacyAuthMiddleware` only:
- `terms`, `_ref_reqs`, `_connect`, `obj_meta`, `metadata`

**Unchanged**: `xsrf` route (has its own auth logic)

### PHP parity
- Every PHP handler starts with `Auth()` → now `legacyAuthMiddleware` runs first
- Every PHP POST handler checks `$_POST["_xsrf"]` → now `legacyXsrfCheck` runs second
- PHP DDL handlers check `Check_Grant(0, 0, "WRITE")` → now `legacyDdlGrantCheck` runs third
- `req.legacyUser` is pre-populated with `{uid, username, xsrf, role, roleId, grants}`

## Test plan

- [x] All 31 Phase 1 unit tests still pass
- [x] 27 new integration tests added for middleware wiring
- [x] No new regressions (17 pre-existing "socket hang up" failures in supertest unchanged)
- [ ] Unauthenticated POST to `_m_new` → 401
- [ ] Authenticated POST with wrong XSRF → error (HTTP 200)
- [ ] DDL route without WRITE grant → error
- [ ] `xsrf` route still works without middleware

> Note: Route-level integration tests (both pre-existing and new) all fail with "socket hang up" due to a pre-existing supertest infrastructure issue unrelated to this PR.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)