### PR TITLE
feat: _d_req — MULTI_MASK auto-application (#226)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -6762,7 +6762,8 @@ router.post('/:db/_d_req/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
     const name = req.body.val || req.body.name || '';
     const alias = req.body.alias || null;
     const required = req.body.required === '1' || req.body.required === true;
-    const multi = req.body.multi === '1' || req.body.multi === true;
+    let multi = req.body.multi === '1' || req.body.multi === true;
+    const multiselect = req.body.multiselect !== undefined;
     const pool = getPool();
 
     if (!name) {
@@ -6795,6 +6796,19 @@ router.post('/:db/_d_req/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
     );
     if (dupeRows.length > 0) {
       return res.status(200).json({ error: `Requisite of type ${reqType} already exists on type ${parentId}` });
+    }
+
+    // 5. MULTI_MASK auto-application (PHP parity: index.php ~8575)
+    // If the requisite type is a reference (its own t is not a basic type)
+    // and the multiselect parameter is set, auto-apply :MULTI: flag.
+    if (!multi && multiselect) {
+      const [reqTypeRows] = await pool.query(
+        `SELECT t FROM \`${db}\` WHERE id = ? LIMIT 1`, [reqType]
+      );
+      if (reqTypeRows.length > 0 && REV_BASE_TYPE[reqTypeRows[0].t] === undefined) {
+        multi = true;
+        logger.info('[Legacy _d_req] MULTI_MASK auto-applied for reference type', { db, reqType });
+      }
     }
 
     // Build value with modifiers


### PR DESCRIPTION
## Summary
- Auto-apply `:MULTI:` flag on requisites based on type characteristics
- Matches PHP behavior from index.php lines 8550–8580
- When `multiselect` parameter is set and the requisite type is a reference (not a basic type), `:MULTI:` is automatically applied

Closes #226

## Test plan
- [ ] Create requisite with multi-eligible type (reference to user-defined type) with `multiselect` param → should auto-get MULTI flag
- [ ] Create requisite with basic type (CHARS, NUMBER, etc.) with `multiselect` param → should not get MULTI flag
- [ ] Create requisite with `multi=1` explicitly → should get MULTI regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)