### PR TITLE
feat: _d_alias — hierarchy check (parent.up=0) (#227)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -6858,6 +6858,12 @@ router.post('/:db/_d_alias/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
       return res.status(404).json({ error: 'Requisite not found' });
     }
 
+    // PHP parity (lines 8604-8607): hierarchy check — parent (obj.t) must be metadata root (up=0)
+    const parent = await getObjectById(db, obj.t);
+    if (!parent || parent.up !== 0) {
+      return res.status(200).json({ error: 'Error in subordination of the link object' });
+    }
+
     // Parse existing modifiers
     const modifiers = parseModifiers(obj.val);
 


### PR DESCRIPTION
## Summary
- Add hierarchy check before alias changes — parent must be metadata (up=0)
- Matches PHP behavior from index.php lines 8600–8626

Closes #227

## Test plan
- [ ] Change alias on metadata-level requisite → should succeed
- [ ] Change alias on non-metadata requisite → should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)