### PR TITLE
feat: BKI delimiter functions (#245)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -609,6 +609,29 @@ function htmlEsc(str) {
     .replace(/"/g, '&quot;');
 }
 
+// ── BKI delimiter helpers (PHP index.php lines 1619-1634) ──────────────
+// MaskDelimiters:   escape  \  →  \\   then  :  →  \:   then  ;  →  \;
+function MaskDelimiters(v) {
+  if (!v && v !== 0) return '';
+  return String(v).replace(/\\/g, '\\\\').replace(/:/g, '\\:').replace(/;/g, '\\;');
+}
+// HideDelimiters:   \\  →  %5C   \:  →  %3A   \;  →  %3B   \,  →  %2C
+function HideDelimiters(v) {
+  if (!v && v !== 0) return '';
+  return String(v).replace(/\\\\/g, '%5C').replace(/\\:/g, '%3A').replace(/\\;/g, '%3B').replace(/\\,/g, '%2C');
+}
+// UnHideDelimiters: reverse of HideDelimiters
+function UnHideDelimiters(v) {
+  if (!v && v !== 0) return '';
+  return String(v).replace(/%5C/g, '\\\\').replace(/%3A/g, '\\:').replace(/%3B/g, '\\;').replace(/%2C/g, '\\,');
+}
+// UnMaskDelimiters: unhide first, then unescape  \\  →  \   \:  →  :   \;  →  ;
+function UnMaskDelimiters(v) {
+  if (!v && v !== 0) return '';
+  const s = UnHideDelimiters(String(v));
+  return s.replace(/\\;/g, ';').replace(/\\:/g, ':').replace(/\\\\/g, '\\');
+}
+
 // PHP GetSha(i) = sha1(Salt(z, i)) = sha1(SALT + z.toUpperCase() + z + i)
 function fileGetSha(db, i) {
   return crypto.createHash('sha1').update(phpSalt(db, String(i), db)).digest('hex');


### PR DESCRIPTION
## Summary
- Port 4 BKI delimiter functions from PHP: MaskDelimiters, UnMaskDelimiters, HideDelimiters, UnHideDelimiters
- Matches PHP behavior from index.php lines 1619–1634

Closes #245

## Test plan
- [ ] MaskDelimiters → properly escapes BKI delimiters
- [ ] UnMaskDelimiters → properly restores them
- [ ] Round-trip: UnMask(Mask(str)) === str

🤖 Generated with [Claude Code](https://claude.com/claude-code)