### PR TITLE
feat: Slash_semi / UnSlash_semi — semicolon escaping (#246)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -632,6 +632,18 @@ function UnMaskDelimiters(v) {
   return s.replace(/\\;/g, ';').replace(/\\:/g, ':').replace(/\\\\/g, '\\');
 }
 
+// ── Semicolon escaping helpers (PHP index.php lines 3940-3947) ─────────
+// Slash_semi:   \;  →  \$L3sH   (protect escaped semicolons before splitting)
+function Slash_semi(str) {
+  if (!str && str !== 0) return '';
+  return String(str).replace(/\\;/g, '\\$L3sH');
+}
+// UnSlash_semi: \$L3sH  →  ;   (restore semicolons after splitting)
+function UnSlash_semi(str) {
+  if (!str && str !== 0) return '';
+  return String(str).replace(/\\\$L3sH/g, ';');
+}
+
 // PHP GetSha(i) = sha1(Salt(z, i)) = sha1(SALT + z.toUpperCase() + z + i)
 function fileGetSha(db, i) {
   return crypto.createHash('sha1').update(phpSalt(db, String(i), db)).digest('hex');


### PR DESCRIPTION
## Summary
- Port Slash_semi() and UnSlash_semi() from PHP
- Matches PHP behavior from index.php lines 3940–3947

Closes #246

## Test plan
- [ ] Slash_semi escapes semicolons properly
- [ ] UnSlash_semi restores them
- [ ] Round-trip works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)