### PR TITLE
feat: BatchDelete — batch DELETE for large trees (#249)

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
+++ b/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
@@ -668,10 +668,10 @@ describe('resolveBuiltIn', () => {
   });
 });
 
-describe('recursiveDelete', () => {
+describe('recursiveDelete (batch)', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
-  it('deletes a leaf node (no children)', async () => {
+  it('deletes a leaf node (no children) using batch IN()', async () => {
     const queries = [];
     const pool = {
       query: vi.fn(async (sql, params) => {
@@ -683,29 +683,51 @@ describe('recursiveDelete', () => {
 
     await recursiveDelete(pool, DB, 100);
 
-    // Should query for children, then delete self
+    // Should query for children, then batch-delete self
     expect(queries).toHaveLength(2);
     expect(queries[0].sql).toContain('SELECT');
     expect(queries[0].params).toEqual([100]);
     expect(queries[1].sql).toContain('DELETE');
+    expect(queries[1].sql).toContain('IN');
     expect(queries[1].params).toEqual([100]);
   });
 
-  it('recursively deletes children before parent', async () => {
-    const deletedIds = [];
+  it('recursively deletes children before parent using batch IN()', async () => {
+    const deletedBatches = [];
     const pool = {
       query: vi.fn(async (sql, params) => {
         if (sql.includes('SELECT') && params[0] === 1) return [[{ id: 2 }, { id: 3 }]];
         if (sql.includes('SELECT')) return [[]]; // leaves
-        if (sql.includes('DELETE')) { deletedIds.push(params[0]); return [{ affectedRows: 1 }]; }
+        if (sql.includes('DELETE')) { deletedBatches.push([...params]); return [{ affectedRows: params.length }]; }
         return [[]];
       }),
     };
 
     await recursiveDelete(pool, DB, 1);
 
-    // Children deleted before parent
-    expect(deletedIds).toEqual([2, 3, 1]);
+    // All IDs deleted in a single batch: children first, then parent
+    expect(deletedBatches).toHaveLength(1);
+    expect(deletedBatches[0]).toEqual([2, 3, 1]);
+  });
+
+  it('handles deep trees: grandchildren deleted before children before parent', async () => {
+    const deletedBatches = [];
+    const pool = {
+      query: vi.fn(async (sql, params) => {
+        // Tree: 1 -> [2, 3], 2 -> [4], 3 -> [], 4 -> []
+        if (sql.includes('SELECT') && params[0] === 1) return [[{ id: 2 }, { id: 3 }]];
+        if (sql.includes('SELECT') && params[0] === 2) return [[{ id: 4 }]];
+        if (sql.includes('SELECT')) return [[]]; // leaves
+        if (sql.includes('DELETE')) { deletedBatches.push([...params]); return [{ affectedRows: params.length }]; }
+        return [[]];
+      }),
+    };
+
+    await recursiveDelete(pool, DB, 1);
+
+    // Single batch: 4 (leaf), 2 (its parent), 3 (leaf), 1 (root)
+    expect(deletedBatches).toHaveLength(1);
+    expect(deletedBatches[0]).toEqual([4, 2, 3, 1]);
   });
 });
 
@@ -726,7 +748,7 @@ describe('checkDuplicatedReqs', () => {
       query: vi.fn(async (sql, params) => {
         if (sql.includes('ORDER BY')) return [[{ id: 10 }, { id: 8 }, { id: 5 }]];
         if (sql.includes('SELECT')) return [[]]; // no children for recursive delete
-        if (sql.includes('DELETE')) { deletedIds.push(params[0]); return [{ affectedRows: 1 }]; }
+        if (sql.includes('DELETE')) { deletedIds.push(...params); return [{ affectedRows: params.length }]; }
         return [[]];
       }),
     };

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -2049,27 +2049,50 @@ function resolveAllBracketBuiltIns(val, userCtx) {
 }
 
 /**
- * Recursively delete object and all descendants.
- * PHP parity: PHP Delete() — current Node uses flat deleteChildren which misses nested levels.
+ * Recursively delete object and all descendants using batch DELETE.
+ * PHP parity: PHP BatchDelete() (index.php lines 1529–1573).
+ *
+ * Instead of deleting one row at a time, this collects all descendant IDs
+ * first, then deletes in batches using DELETE ... WHERE id IN (...).
+ * Batches flush every BATCH_DELETE_THRESHOLD IDs to bound memory and query size.
  *
  * @param {Object} pool - MySQL pool
  * @param {string} db   - database name
  * @param {number} id   - object ID to delete
  */
+const BATCH_DELETE_THRESHOLD = 1000;
+
 async function recursiveDelete(pool, db, id) {
-  // Get all children first
+  // Collect all IDs to delete (children-first / bottom-up order)
+  const idsToDelete = [];
+  await _collectDescendants(pool, db, id, idsToDelete);
+  // Root node last
+  idsToDelete.push(id);
+
+  // Delete in batches
+  for (let i = 0; i < idsToDelete.length; i += BATCH_DELETE_THRESHOLD) {
+    const batch = idsToDelete.slice(i, i + BATCH_DELETE_THRESHOLD);
+    const placeholders = batch.map(() => '?').join(',');
+    await pool.query(`DELETE FROM ${db} WHERE id IN (${placeholders})`, batch);
+  }
+}
+
+/**
+ * Recursively collect all descendant IDs (children-first).
+ * @param {Object} pool
+ * @param {string} db
+ * @param {number} parentId
+ * @param {number[]} acc - accumulator array, mutated in-place
+ */
+async function _collectDescendants(pool, db, parentId, acc) {
   const [children] = await pool.query(
     `SELECT id FROM ${db} WHERE up = ?`,
-    [id]
+    [parentId]
   );
-
-  // Recurse for each child
   for (const child of children) {
-    await recursiveDelete(pool, db, child.id);
+    await _collectDescendants(pool, db, child.id, acc);
+    acc.push(child.id);
   }
-
-  // Delete self
-  await pool.query(`DELETE FROM ${db} WHERE id = ?`, [id]);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implement batch DELETE using `IN()` clause for large tree deletions instead of one-row-at-a-time recursive deletes
- Collects all descendant IDs bottom-up, then deletes in batches of 1000
- Matches PHP `BatchDelete()` from `index.php` lines 1529-1573
- Updated tests to verify batch IN() behavior including deep tree scenarios

Closes #249

## Test plan
- [x] Unit tests pass: leaf node, parent+children, deep tree (grandchildren)
- [ ] Delete large tree in production DB -> uses batch DELETE
- [ ] Small deletions (single object, type, requisite) -> still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)