### PR TITLE
feat: t9n — i18n for error messages (#253)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -15,6 +15,7 @@ import multer from 'multer';
 import nodemailer from 'nodemailer';
 import { phpJsonMiddleware } from '../../utils/jsonSortKeys.js';
 import { isAbnPostProcessFunction, applyAbnFunction, isAbnFunction, ABN_SQL_FIELD_FUNCS } from '../utils/report-functions.js';
+import { t9n, getLocale } from '../../utils/t9n.js';
 
 const router = express.Router();
 
@@ -1788,8 +1789,9 @@ function constructWhere(key, filter, curTyp, joinReq, ctx) {
  */
 async function legacyAuthMiddleware(req, res, next) {
   const db = req.params.db;
+  const locale = getLocale(req, db);
   if (!db || !isValidDbName(db)) {
-    return res.status(401).json({ error: 'Invalid database' });
+    return res.status(401).json({ error: t9n('invalid_database', locale) });
   }
 
   const token = extractToken(req, db);
@@ -1897,10 +1899,10 @@ async function legacyAuthMiddleware(req, res, next) {
     }
 
     // No guest user defined — reject
-    return res.status(401).json({ error: token ? 'Invalid or expired token' : 'Authentication required' });
+    return res.status(401).json({ error: t9n(token ? 'invalid_token' : 'auth_required', locale) });
   } catch (error) {
     logger.error({ error: error.message, db }, '[legacyAuthMiddleware] Error');
-    return res.status(401).json({ error: 'Authentication failed' });
+    return res.status(401).json({ error: t9n('auth_failed', locale) });
   }
 }
 
@@ -1921,7 +1923,8 @@ function legacyXsrfCheck(req, res, next) {
 
   if (!xsrf || bodyXsrf !== xsrf) {
     // HTTP 200 matching PHP my_die() behavior
-    return res.status(200).json({ error: 'Invalid or expired CSRF token' });
+    const locale = getLocale(req, req.params.db);
+    return res.status(200).json({ error: t9n('invalid_csrf', locale) });
   }
 
   next();
@@ -1939,14 +1942,16 @@ async function legacyDdlGrantCheck(req, res, next) {
 
   try {
     const pool = getPool();
+    const locale = getLocale(req, db);
     const hasGrant = await checkGrant(pool, db, grants || {}, 0, 0, 'WRITE', username || '');
     if (!hasGrant) {
-      return res.status(200).json({ error: 'Insufficient privileges for type modification' });
+      return res.status(200).json({ error: t9n('insufficient_type_mod', locale) });
     }
     next();
   } catch (error) {
     logger.error({ error: error.message, db }, '[legacyDdlGrantCheck] Error');
-    return res.status(200).json({ error: 'Grant check failed' });
+    const locale = getLocale(req, db);
+    return res.status(200).json({ error: t9n('grant_check_failed', locale) });
   }
 }
 
@@ -2380,9 +2385,10 @@ router.get('/:db/auth', async (req, res, next) => {
   if (req.query.secret !== undefined) return next();
   const { db } = req.params;
   if (!isApiRequest(req)) return next();
-  if (!isValidDbName(db)) return res.status(200).json({ error: 'Invalid database name' });
+  const locale = getLocale(req, db);
+  if (!isValidDbName(db)) return res.status(200).json({ error: t9n('invalid_database_name', locale) });
   const token = extractToken(req, db);
-  if (!token) return res.status(200).json({ error: 'not logged' });
+  if (!token) return res.status(200).json({ error: t9n('not_logged', locale) });
   try {
     const pool = getPool();
     const [rows] = await pool.query(
@@ -2393,13 +2399,13 @@ router.get('/:db/auth', async (req, res, next) => {
        WHERE u.t = ${TYPE.USER} LIMIT 1`,
       [token]
     );
-    if (rows.length === 0) return res.status(200).json({ error: 'not logged' });
+    if (rows.length === 0) return res.status(200).json({ error: t9n('not_logged', locale) });
     const u = rows[0];
     const xsrf = u.xsrf_val || generateXsrf(token, u.uname || '', db);
     return res.status(200).json({ _xsrf: xsrf, token, id: Number(u.uid), msg: '' });
   } catch (err) {
     logger.error('[GET /:db/auth] DB error', { error: err.message, db });
-    return res.status(200).json({ error: 'server error' });
+    return res.status(200).json({ error: t9n('server_error', locale) });
   }
 });
 
@@ -2410,9 +2416,10 @@ router.all('/:db/auth', async (req, res, next) => {
   const { db } = req.params;
   const isJSON = isApiRequest(req);
 
+  const locale = getLocale(req, db);
   if (!isValidDbName(db)) {
-    if (isJSON) return res.status(200).json({ error: 'Invalid database name' });
-    return res.status(400).send('Invalid database');
+    if (isJSON) return res.status(200).json({ error: t9n('invalid_database_name', locale) });
+    return res.status(400).send(t9n('invalid_database', locale));
   }
 
   try {
@@ -2435,8 +2442,8 @@ router.all('/:db/auth', async (req, res, next) => {
 
     if (rows.length === 0) {
       logger.warn('[Legacy SecretAuth] Invalid secret token', { db });
-      if (isJSON) return res.status(200).json({ error: 'Invalid secret token' });
-      return res.status(401).send('Invalid secret token');
+      if (isJSON) return res.status(200).json({ error: t9n('invalid_secret', locale) });
+      return res.status(401).send(t9n('invalid_secret', locale));
     }
 
     const user = rows[0];
@@ -2512,12 +2519,13 @@ router.post('/:db/auth', async (req, res, next) => {
 
   logger.info('[Legacy Auth] Request', { db, isJSON, body: { ...req.body, pwd: '***', npw1: '***', npw2: '***' } });
 
+  const locale = getLocale(req, db);
   // Validate DB name
   if (!isValidDbName(db)) {
     if (isJSON) {
-      return res.status(200).json({ error: 'Invalid database name' });
+      return res.status(200).json({ error: t9n('invalid_database_name', locale) });
     }
-    return res.status(400).send('Invalid database');
+    return res.status(400).send(t9n('invalid_database', locale));
   }
 
   // PHP lowercases the login: $u = strtolower($_POST["login"])
@@ -2534,9 +2542,9 @@ router.post('/:db/auth', async (req, res, next) => {
 
   if (!login || !password) {
     if (isJSON) {
-      return res.status(200).json({ error: 'Login and password required' });
+      return res.status(200).json({ error: t9n('login_password_required', locale) });
     }
-    return res.status(400).send('Login and password required');
+    return res.status(400).send(t9n('login_password_required', locale));
   }
 
   try {
@@ -3469,30 +3477,35 @@ router.post('/my/register', async (req, res) => {
   logger.info('[Legacy Register] Request', { email });
 
   // Validate input
+  const locale = getLocale(req, 'my');
   if (!email || !/^.+@.+\..+$/.test(email)) {
+    const msg = t9n('invalid_email', locale);
     if (isJSON) {
-      return res.json({ error: 'Please provide a valid email' });
+      return res.json({ error: msg });
     }
-    return res.status(400).send('Please provide a valid email');
+    return res.status(400).send(msg);
   }
 
   if (!regpwd || regpwd.length < 6) {
+    const msg = t9n('password_too_short', locale);
     if (isJSON) {
-      return res.json({ error: 'Password must be at least 6 characters' });
+      return res.json({ error: msg });
     }
-    return res.status(400).send('Password must be at least 6 characters');
+    return res.status(400).send(msg);
   }
 
   if (regpwd !== regpwd1) {
+    const msg = t9n('passwords_mismatch', locale);
     if (isJSON) {
-      return res.json({ error: 'Passwords do not match' });
+      return res.json({ error: msg });
     }
-    return res.status(400).send('Passwords do not match');
+    return res.status(400).send(msg);
   }
 
   if (!agree) {
-    if (isJSON) return res.json({ error: 'Please accept the terms' });
-    return res.status(400).send('Please accept the terms');
+    const msg = t9n('accept_terms', locale);
+    if (isJSON) return res.json({ error: msg });
+    return res.status(400).send(msg);
   }
 
   // PHP creates the user in the 'my' table (multi-tenant global users DB).
@@ -3512,8 +3525,9 @@ router.post('/my/register', async (req, res) => {
         [email.toLowerCase()]
       );
       if (existing.length > 0) {
-        if (isJSON) return res.json({ error: 'This email is already registered. [errMailExists]' });
-        return res.status(400).send('This email is already registered.');
+        const msg = t9n('email_registered', locale) + ' [errMailExists]';
+        if (isJSON) return res.json({ error: msg });
+        return res.status(400).send(msg);
       }
 
       // PHP newUser($email, $email, "115", "", "") — Insert(1, 0, USER, email, ...)
@@ -5361,8 +5375,9 @@ router.post('/:db/_m_new/:up?', legacyAuthMiddleware, legacyXsrfCheck, (req, res
 }, async (req, res) => {
   const { db, up } = req.params;
 
+  const locale = getLocale(req, db);
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json({ error: t9n('invalid_database', locale) });
   }
 
   try {
@@ -5387,10 +5402,10 @@ router.post('/:db/_m_new/:up?', legacyAuthMiddleware, legacyXsrfCheck, (req, res
 
     // Reject invalid parentId and typeId
     if (parentId === 0) {
-      return res.status(200).json({ error: 'Parent ID cannot be 0' });
+      return res.status(200).json({ error: t9n('parent_id_zero', locale) });
     }
     if (!typeId || typeId === 0) {
-      return res.status(200).json({ error: 'Type ID (t or type) is required'  });
+      return res.status(200).json({ error: t9n('type_required', locale) });
     }
 
     // Verify type and parent exist

--- a/backend/monolith/src/utils/__tests__/t9n.test.js
+++ b/backend/monolith/src/utils/__tests__/t9n.test.js
@@ -1,0 +1,81 @@
+/**
+ * t9n() — i18n translation function tests (Issue #253)
+ *
+ * Tests for dictionary-based and PHP-compatible inline translation modes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { t9n } from '../t9n.js';
+
+describe('t9n — i18n translation function', () => {
+  describe('dictionary mode', () => {
+    it('returns English message by default', () => {
+      expect(t9n('invalid_database')).toBe('Invalid database');
+    });
+
+    it('returns Russian message when locale is RU', () => {
+      expect(t9n('invalid_database', 'RU')).toBe('Неверная база данных');
+    });
+
+    it('returns English message when locale is EN', () => {
+      expect(t9n('auth_failed', 'EN')).toBe('Authentication failed');
+    });
+
+    it('locale is case-insensitive', () => {
+      expect(t9n('invalid_database', 'ru')).toBe('Неверная база данных');
+      expect(t9n('invalid_database', 'en')).toBe('Invalid database');
+    });
+
+    it('unknown key returns key as-is', () => {
+      expect(t9n('some_unknown_key')).toBe('some_unknown_key');
+      expect(t9n('some_unknown_key', 'RU')).toBe('some_unknown_key');
+    });
+
+    it('empty/null key returns empty string', () => {
+      expect(t9n('')).toBe('');
+      expect(t9n(null)).toBe('');
+      expect(t9n(undefined)).toBe('');
+    });
+  });
+
+  describe('inline mode (PHP compat)', () => {
+    it('extracts RU text', () => {
+      expect(t9n('[RU]Текст[EN]Text', 'RU')).toBe('Текст');
+    });
+
+    it('extracts EN text', () => {
+      expect(t9n('[RU]Текст[EN]Text', 'EN')).toBe('Text');
+    });
+
+    it('extracts text when locale is last segment', () => {
+      expect(t9n('[RU]Русский[EN]English', 'EN')).toBe('English');
+    });
+
+    it('returns original when locale not found', () => {
+      expect(t9n('[RU]Текст[EN]Text', 'DE')).toBe('[RU]Текст[EN]Text');
+    });
+
+    it('handles multiline content', () => {
+      const msg = '[RU]Строка 1\nСтрока 2[EN]Line 1\nLine 2';
+      expect(t9n(msg, 'RU')).toBe('Строка 1\nСтрока 2');
+      expect(t9n(msg, 'EN')).toBe('Line 1\nLine 2');
+    });
+  });
+
+  describe('common dictionary keys', () => {
+    it.each([
+      ['not_logged', 'EN', 'not logged'],
+      ['not_logged', 'RU', 'Не авторизован'],
+      ['password_too_short', 'EN', 'Password must be at least 6 characters'],
+      ['password_too_short', 'RU', 'Пароль должен быть не менее 6 символов'],
+      ['server_error', 'EN', 'server error'],
+      ['server_error', 'RU', 'Ошибка сервера'],
+      ['object_not_found', 'EN', 'Object not found'],
+      ['object_not_found', 'RU', 'Объект не найден'],
+      ['insufficient_privileges', 'EN', 'Insufficient privileges'],
+      ['insufficient_privileges', 'RU', 'Недостаточно прав'],
+    ])('t9n(%s, %s) → %s', (key, lang, expected) => {
+      expect(t9n(key, lang)).toBe(expected);
+    });
+  });
+});

--- a/backend/monolith/src/utils/t9n.js
+++ b/backend/monolith/src/utils/t9n.js
@@ -1,0 +1,125 @@
+// t9n() — i18n for error messages (PHP parity: index.php lines 560–572)
+//
+// Two modes:
+//   1. Dictionary mode:  t9n('invalid_database', 'RU') → 'Неверная база данных'
+//   2. Inline mode (PHP compat):  t9n('[RU]Текст[EN]Text', 'EN') → 'Text'
+//
+// If key is not found in dictionary and doesn't contain inline markers,
+// the key itself is returned as-is.
+
+const dictionary = {
+  // --- Authentication & authorization ---
+  invalid_database:           { RU: 'Неверная база данных',             EN: 'Invalid database' },
+  invalid_database_name:      { RU: 'Неверное имя базы данных',         EN: 'Invalid database name' },
+  database_not_found:         { RU: 'База данных не найдена',           EN: 'Database not found' },
+  not_logged:                 { RU: 'Не авторизован',                   EN: 'not logged' },
+  auth_required:              { RU: 'Требуется авторизация',            EN: 'Authentication required' },
+  auth_failed:                { RU: 'Ошибка авторизации',               EN: 'Authentication failed' },
+  invalid_token:              { RU: 'Неверный или просроченный токен',   EN: 'Invalid or expired token' },
+  invalid_csrf:               { RU: 'Неверный или просроченный CSRF токен', EN: 'Invalid or expired CSRF token' },
+  invalid_secret:             { RU: 'Неверный секретный токен',         EN: 'Invalid secret token' },
+  login_required:             { RU: 'Необходимо войти в систему',       EN: 'Login required' },
+  login_password_required:    { RU: 'Необходимо указать логин и пароль', EN: 'Login and password required' },
+  invalid_credentials:        { RU: 'Неверные учетные данные',          EN: 'Invalid credentials' },
+  unauthorized:               { RU: 'Нет доступа',                     EN: 'Unauthorized' },
+  insufficient_privileges:    { RU: 'Недостаточно прав',                EN: 'Insufficient privileges' },
+  grant_check_failed:         { RU: 'Проверка прав доступа не пройдена', EN: 'Grant check failed' },
+
+  // --- Validation ---
+  invalid_email:              { RU: 'Вы ввели неверный email',          EN: 'Please provide a valid email' },
+  empty_password:             { RU: 'Введен пустой пароль',             EN: 'Please input the password' },
+  password_too_short:         { RU: 'Пароль должен быть не менее 6 символов', EN: 'Password must be at least 6 characters' },
+  passwords_mismatch:         { RU: 'Введенные вами пароли не совпадают', EN: 'Passwords do not match' },
+  accept_terms:               { RU: 'Пожалуйста, примите условия соглашения', EN: 'Please accept the terms' },
+  email_registered:           { RU: 'Этот email уже зарегистрирован.',  EN: 'This email is already registered.' },
+  invalid_data:               { RU: 'Неверные данные',                  EN: 'invalid data' },
+  invalid_user:               { RU: 'Неверный пользователь',            EN: 'invalid user' },
+  user_not_found:             { RU: 'Пользователь не найден',           EN: 'user not found' },
+
+  // --- Objects ---
+  object_not_found:           { RU: 'Объект не найден',                 EN: 'Object not found' },
+  cannot_modify_meta:         { RU: 'Нельзя изменить объект метаданных', EN: 'Cannot modify metadata object' },
+  cannot_move_meta:           { RU: 'Нельзя переместить объект метаданных', EN: 'Cannot move metadata object' },
+  cannot_delete_self:         { RU: 'Вы не можете удалить себя',        EN: 'You cannot delete yourself' },
+  no_attributes:              { RU: 'Атрибуты не указаны',              EN: 'No attributes provided' },
+  parent_not_found:           { RU: 'Родительский объект не найден',    EN: 'Parent not found' },
+  parent_id_zero:             { RU: 'ID родителя не может быть 0',      EN: 'Parent ID cannot be 0' },
+  type_required:              { RU: 'Тип (t или type) обязателен',      EN: 'Type ID (t or type) is required' },
+  type_not_found:             { RU: 'Тип не найден',                    EN: 'Type not found' },
+  type_name_required:         { RU: 'Имя типа (val) обязательно',       EN: 'Type name (val) is required' },
+  base_type_not_set:          { RU: 'Базовый тип не задан',             EN: 'Base type is not set' },
+  no_fields_to_update:        { RU: 'Нет полей для обновления',         EN: 'No fields to update' },
+  rename_admin_forbidden:     { RU: 'Создайте другого пользователя вместо переименования администратора', EN: 'Please create another user instead of renaming the admin' },
+  reference_not_found:        { RU: 'Ссылка не найдена',                EN: 'Reference not found' },
+  insufficient_target:        { RU: 'Недостаточно прав для целевого родителя', EN: 'Insufficient privileges for target parent' },
+  insufficient_type_mod:      { RU: 'Недостаточно прав для изменения типов', EN: 'Insufficient privileges for type modification' },
+
+  // --- Files ---
+  wrong_extension:            { RU: 'Недопустимый тип файла!',          EN: 'Wrong file extension!' },
+  cannot_delete_file:         { RU: 'Не удалось удалить файл',          EN: 'Cannot delete the file' },
+  cannot_open_file:           { RU: 'Не удается открыть файл',          EN: 'Cannot open file' },
+
+  // --- Reports ---
+  empty_report:               { RU: 'Пустой отчет',                    EN: 'Empty report' },
+  report_link_failed:         { RU: 'Не могу связать колонки отчета.',  EN: 'Failed to link the columns of the report.' },
+
+  // --- General ---
+  server_error:               { RU: 'Ошибка сервера',                  EN: 'server error' },
+  connection_failed:          { RU: 'Не удалось подключиться',          EN: 'Connection failed' },
+  reset_failed:               { RU: 'Сброс не удался',                 EN: 'Reset failed' },
+  wrong_date:                 { RU: 'Неверная дата',                    EN: 'Wrong date' },
+  invalid_format:             { RU: 'Неверный формат или нечисловые ID', EN: 'Invalid format or non-numeric IDs' },
+  google_oauth_not_configured: { RU: 'Google OAuth не настроен на этом сервере', EN: 'Google OAuth is not configured on this server' },
+  google_auth_failed:         { RU: 'Ошибка аутентификации Google',     EN: 'Google authentication failed' },
+  auth_error:                 { RU: 'Ошибка аутентификации',            EN: 'Authentication error' },
+  user_registry_unavailable:  { RU: 'Реестр пользователей недоступен',  EN: 'User registry not available' },
+  missing_auth_code:          { RU: 'Отсутствует код авторизации',      EN: 'Missing authorization code' },
+  registration_failed:        { RU: 'Ошибка регистрации',               EN: 'Registration failed' },
+};
+
+/**
+ * Translate a message key or inline-formatted string.
+ *
+ * PHP-compatible inline format: "[RU]Текст[EN]Text"
+ * Dictionary mode:              t9n('invalid_database', 'RU')
+ *
+ * @param {string} key  - dictionary key OR inline-formatted string
+ * @param {string} lang - locale code: 'RU', 'EN', etc. (default 'EN')
+ * @returns {string} translated message
+ */
+export function t9n(key, lang = 'EN') {
+  if (!key) return '';
+
+  const locale = (lang || 'EN').toUpperCase();
+
+  // --- Inline mode (PHP compat): "[RU]Текст[EN]Text" ---
+  if (key.includes('[') && /\[[A-Z]{2}\]/.test(key)) {
+    const marker = `[${locale}]`;
+    const idx = key.indexOf(marker);
+    if (idx === -1) return key;
+    const rest = key.slice(idx + marker.length);
+    const match = rest.match(/^([\s\S]*?)(?:\[[A-Z]{2}\]|$)/);
+    return match ? match[1] : rest;
+  }
+
+  // --- Dictionary mode ---
+  const entry = dictionary[key];
+  if (!entry) return key;
+  return entry[locale] || entry.EN || key;
+}
+
+/**
+ * Helper: extract locale from Express request (mirrors PHP $locale logic).
+ * Checks cookie <db>_locale, then my_locale, defaults to 'RU'.
+ *
+ * @param {object} req - Express request
+ * @param {string} db  - database name
+ * @returns {string} 'RU' | 'EN' | ...
+ */
+export function getLocale(req, db) {
+  return req.cookies?.[(db || '') + '_locale']
+    || req.cookies?.my_locale
+    || 'RU';
+}
+
+export default t9n;


### PR DESCRIPTION
## Summary
- Implement `t9n(key, lang)` translation function for error/status messages (PHP parity: `index.php` lines 560-572)
- Dictionary-based mode with 40+ common error keys in Russian and English
- PHP-compatible inline format mode (`[RU]Текст[EN]Text`) for backward compatibility
- `getLocale(req, db)` helper mirrors PHP `$locale` cookie logic
- Integrated into `legacy-compat.js` auth middleware, XSRF check, DDL grant check, registration validation, and auth endpoints

Closes #253

## Test plan
- [x] `t9n('key', 'RU')` returns Russian message
- [x] `t9n('key', 'EN')` returns English message
- [x] Unknown key returns key as-is
- [x] Inline `[RU]...[EN]...` format works (PHP compat)
- [ ] Vitest unit tests in `__tests__/t9n.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)