### PR TITLE
feat: getJsonVal / checkJson — JSON utilities for reports (#257)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -14,7 +14,7 @@ import cookieParser from 'cookie-parser';
 import multer from 'multer';
 import nodemailer from 'nodemailer';
 import { phpJsonMiddleware } from '../../utils/jsonSortKeys.js';
-import { isAbnPostProcessFunction, applyAbnFunction, isAbnFunction, ABN_SQL_FIELD_FUNCS } from '../utils/report-functions.js';
+import { isAbnPostProcessFunction, applyAbnFunction, isAbnFunction, ABN_SQL_FIELD_FUNCS, getJsonVal, checkJson } from '../utils/report-functions.js';
 import { t9n, getLocale } from '../../utils/t9n.js';
 
 const router = express.Router();
@@ -10294,6 +10294,9 @@ async function executeReport(pool, db, report, filters = {}, limit = 100, offset
     // ── Map rows → named output ───────────────────────────────────────────
     // Collect columns that need abn_* post-processing (PHP parity: index.php:3364)
     const abnPostCols = report.columns.filter(c => c.func && isAbnPostProcessFunction(c.func));
+    // Collect columns with JSON formula extraction (PHP parity: index.php:3490-3506)
+    const jsonFormulaCols = report.columns.filter(c => c.formula &&
+      (c.formula.toUpperCase().startsWith('JSON.') || c.formula.toUpperCase().startsWith('CURL.') || c.formula.toUpperCase().startsWith("'CURL.")));
     let rownum = 1;
     results.data = rows.map(row => {
       const out = { id: row.id, val: row.main_val };
@@ -10311,6 +10314,19 @@ async function executeReport(pool, db, report, filters = {}, limit = 100, offset
       // Apply abn_* post-processing functions (abn_DATE2STR, abn_NUM2STR, etc.)
       for (const col of abnPostCols) {
         out[col.alias] = applyAbnFunction(col.func, out[col.alias]);
+      }
+      // Apply JSON formula extraction (PHP parity: index.php:3490-3506)
+      // When REP_COL_FORMULA starts with "JSON.", extract the named key from the cell value.
+      // When REP_COL_FORMULA starts with "CURL." or "'CURL.", extract from curl response (if available).
+      for (const col of jsonFormulaCols) {
+        const formula = col.formula;
+        const cellVal = String(out[col.alias] ?? '');
+        if (formula.toUpperCase().startsWith('JSON.')) {
+          const jsonKey = formula.substring(5); // strip "JSON."
+          if (jsonKey && cellVal.toUpperCase().indexOf(jsonKey.toUpperCase()) !== -1) {
+            out[col.alias] = checkJson(jsonKey, cellVal);
+          }
+        }
       }
       return out;
     });

--- a/backend/monolith/src/api/utils/__tests__/report-functions-json.test.js
+++ b/backend/monolith/src/api/utils/__tests__/report-functions-json.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { getJsonVal, checkJson } from '../report-functions.js';
+
+describe('getJsonVal', () => {
+  it('returns value for a direct top-level key', () => {
+    const json = JSON.stringify({ name: 'Alice', age: 30 });
+    expect(getJsonVal('name', json)).toBe('Alice');
+  });
+
+  it('returns JSON-encoded array for a top-level array property', () => {
+    const json = JSON.stringify({ items: [1, 2, 3], other: 'x' });
+    expect(getJsonVal('items', json)).toBe('[1,2,3]');
+  });
+
+  it('finds nested key via recursive walk', () => {
+    const json = JSON.stringify({ data: { inner: { target: 'found' } } });
+    expect(getJsonVal('target', json)).toBe('found');
+  });
+
+  it('returns first match when key appears multiple times', () => {
+    const json = JSON.stringify({ a: { val: 'first' }, b: { val: 'second' } });
+    expect(getJsonVal('val', json)).toBe('first');
+  });
+
+  it('returns original value when key is not found in text (case-insensitive pre-check)', () => {
+    const json = JSON.stringify({ foo: 'bar' });
+    expect(getJsonVal('nothere', json)).toBe(json);
+  });
+
+  it('returns original value for empty jsonKey', () => {
+    const json = JSON.stringify({ a: 1 });
+    expect(getJsonVal('', json)).toBe(json);
+  });
+
+  it('returns original value for invalid JSON', () => {
+    expect(getJsonVal('key', 'not json {{')).toBe('not json {{');
+  });
+
+  it('returns original value for non-string val', () => {
+    expect(getJsonVal('key', 42)).toBe(42);
+  });
+
+  it('handles null JSON value', () => {
+    expect(getJsonVal('key', 'null')).toBe('null');
+  });
+
+  it('finds key inside array elements', () => {
+    const json = JSON.stringify({ list: [{ id: 1 }, { id: 2, name: 'Bob' }] });
+    expect(getJsonVal('name', json)).toBe('Bob');
+  });
+});
+
+describe('checkJson', () => {
+  it('extracts value for a top-level key', () => {
+    const json = JSON.stringify({ status: 'ok', code: 200 });
+    expect(checkJson('status', json)).toBe('ok');
+  });
+
+  it('extracts value for a nested key', () => {
+    const json = JSON.stringify({ response: { data: { result: 42 } } });
+    expect(checkJson('result', json)).toBe(42);
+  });
+
+  it('returns original value when key not found', () => {
+    const json = JSON.stringify({ a: 1 });
+    expect(checkJson('missing', json)).toBe(json);
+  });
+
+  it('returns original value for invalid JSON', () => {
+    expect(checkJson('key', 'bad json')).toBe('bad json');
+  });
+
+  it('returns original value for non-string input', () => {
+    expect(checkJson('key', 123)).toBe(123);
+  });
+
+  it('returns original value for null jsonKey', () => {
+    const json = JSON.stringify({ a: 1 });
+    expect(checkJson(null, json)).toBe(json);
+  });
+
+  it('finds key inside array elements', () => {
+    const json = JSON.stringify([{ x: 10 }, { y: 20, target: 'hit' }]);
+    expect(checkJson('target', json)).toBe('hit');
+  });
+});

--- a/backend/monolith/src/api/utils/report-functions.js
+++ b/backend/monolith/src/api/utils/report-functions.js
@@ -208,6 +208,130 @@ function abn_Translit(s) {
   return result;
 }
 
+// ── JSON utilities (PHP parity: index.php:3912-3939) ──────────────────────
+
+/**
+ * getJsonVal(jsonKey, val) — extract a value from a JSON string by key name.
+ *
+ * PHP behavior (index.php:3912-3931):
+ * 1. If jsonKey is empty or not found (case-insensitive) in val, return val as-is.
+ * 2. First try json_decode as object: if the key exists as a direct property
+ *    and its value is an array, return JSON-encoded array.
+ * 3. Then json_decode as associative array and walk recursively:
+ *    return the first value whose key matches jsonKey (exact, case-sensitive).
+ * 4. If nothing matched, return the original val.
+ *
+ * @param {string} jsonKey - the key to search for
+ * @param {string} val     - JSON string to search in
+ * @returns {*} extracted value or original val
+ */
+function getJsonVal(jsonKey, val) {
+  if (!jsonKey || typeof jsonKey !== 'string' || jsonKey.length === 0) return val;
+  if (typeof val !== 'string') return val;
+
+  // PHP: mb_strpos(strtoupper($val), strtoupper($jsonKey)) !== FALSE
+  if (val.toUpperCase().indexOf(jsonKey.toUpperCase()) === -1) return val;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(val);
+  } catch {
+    return val;
+  }
+
+  if (parsed === null || typeof parsed !== 'object') return val;
+
+  // Step 1: direct property check (PHP: $tmp->$jsonKey)
+  if (jsonKey in parsed) {
+    if (Array.isArray(parsed[jsonKey])) {
+      return JSON.stringify(parsed[jsonKey]);
+    }
+  }
+
+  // Step 2: recursive walk — find first matching key (PHP: array_walk_recursive)
+  let found = false;
+  let result = val;
+
+  function walkRecursive(obj) {
+    if (found) return;
+    if (obj === null || typeof obj !== 'object') return;
+    if (Array.isArray(obj)) {
+      for (const item of obj) {
+        walkRecursive(item);
+        if (found) return;
+      }
+    } else {
+      for (const [k, v] of Object.entries(obj)) {
+        if (found) return;
+        if (k === jsonKey) {
+          found = true;
+          result = v;
+          return;
+        }
+        if (v !== null && typeof v === 'object') {
+          walkRecursive(v);
+        }
+      }
+    }
+  }
+
+  walkRecursive(parsed);
+  return result;
+}
+
+/**
+ * checkJson(jsonKey, val) — extract a value from a JSON string by key name.
+ *
+ * PHP behavior (index.php:3932-3939):
+ * Parses val as JSON associative array, walks recursively to find the first
+ * key matching jsonKey, returns that value. If not found, returns original val.
+ *
+ * @param {string} jsonKey - the key to search for
+ * @param {string} val     - JSON string to search in
+ * @returns {*} extracted value or original val
+ */
+function checkJson(jsonKey, val) {
+  if (!jsonKey || typeof val !== 'string') return val;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(val);
+  } catch {
+    return val;
+  }
+
+  if (parsed === null || typeof parsed !== 'object') return val;
+
+  let found = false;
+  let result = val;
+
+  function walkRecursive(obj) {
+    if (found) return;
+    if (obj === null || typeof obj !== 'object') return;
+    if (Array.isArray(obj)) {
+      for (const item of obj) {
+        walkRecursive(item);
+        if (found) return;
+      }
+    } else {
+      for (const [k, v] of Object.entries(obj)) {
+        if (found) return;
+        if (k === jsonKey) {
+          found = true;
+          result = v;
+          return;
+        }
+        if (v !== null && typeof v === 'object') {
+          walkRecursive(v);
+        }
+      }
+    }
+  }
+
+  walkRecursive(parsed);
+  return result;
+}
+
 // ── Registry: map function name → implementation ─────────────────────────
 
 const ABN_POST_PROCESS_FUNCTIONS = {
@@ -262,6 +386,8 @@ export {
   isAbnFunction,
   isAbnPostProcessFunction,
   applyAbnFunction,
+  getJsonVal,
+  checkJson,
   ABN_POST_PROCESS_FUNCTIONS,
   ABN_SQL_FIELD_FUNCS,
 };


### PR DESCRIPTION
## Summary
- Implement `getJsonVal()` for JSON key extraction from JSON strings (recursive walk with direct property shortcut for arrays)
- Implement `checkJson()` for JSON key extraction via recursive walk
- Integrate JSON formula processing into report execution (formulas starting with `JSON.` extract keys from cell values)
- Matches PHP behavior from `index.php` lines 3912-3939

Closes #257

## Test plan
- [x] getJsonVal with valid path returns value
- [x] getJsonVal with missing path returns original value
- [x] getJsonVal with array property returns JSON-encoded array
- [x] getJsonVal with nested key finds via recursive walk
- [x] checkJson with valid JSON returns extracted value
- [x] checkJson with invalid JSON returns original value
- [x] 17 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)