### PR TITLE
port: implement Check_Types_Grant — metadata access control (#297)

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/check-types-grant.test.js
+++ b/backend/monolith/src/api/routes/__tests__/check-types-grant.test.js
@@ -1,0 +1,90 @@
+/**
+ * checkTypesGrant — Unit tests (Issue #297)
+ *
+ * Port of PHP Check_Types_Grant() (index.php:967).
+ * Authorization gate for type/metadata operations.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkTypesGrant } from '../legacy-compat.js';
+
+describe('checkTypesGrant', () => {
+  describe('admin bypass', () => {
+    it('returns WRITE for admin user regardless of grants', () => {
+      expect(checkTypesGrant({}, 'admin')).toBe('WRITE');
+    });
+
+    it('returns WRITE for admin user with empty grants', () => {
+      expect(checkTypesGrant({}, 'admin', true)).toBe('WRITE');
+    });
+
+    it('returns WRITE for Admin (case-insensitive)', () => {
+      expect(checkTypesGrant({}, 'Admin')).toBe('WRITE');
+      expect(checkTypesGrant({}, 'ADMIN')).toBe('WRITE');
+    });
+
+    it('returns WRITE for admin even when grants[0] is READ', () => {
+      expect(checkTypesGrant({ 0: 'READ' }, 'admin')).toBe('WRITE');
+    });
+  });
+
+  describe('grant ID 0 check', () => {
+    it('returns WRITE when grants[0] is WRITE', () => {
+      expect(checkTypesGrant({ 0: 'WRITE' }, 'someuser')).toBe('WRITE');
+    });
+
+    it('returns READ when grants[0] is READ', () => {
+      expect(checkTypesGrant({ 0: 'READ' }, 'someuser')).toBe('READ');
+    });
+
+    it('throws 403 when grants[0] has invalid value (fatal=true)', () => {
+      expect(() => checkTypesGrant({ 0: 'NONE' }, 'someuser', true))
+        .toThrow('You do not have the grant to view and edit the metadata');
+    });
+
+    it('returns undefined when grants[0] has invalid value (fatal=false)', () => {
+      expect(checkTypesGrant({ 0: 'NONE' }, 'someuser', false)).toBeUndefined();
+    });
+  });
+
+  describe('no grant', () => {
+    it('throws with status 403 when fatal=true and no grants', () => {
+      try {
+        checkTypesGrant({}, 'someuser', true);
+        expect.fail('Should have thrown');
+      } catch (err) {
+        expect(err.message).toBe('You do not have the grant to view and edit the metadata');
+        expect(err.status).toBe(403);
+      }
+    });
+
+    it('throws when fatal defaults to true', () => {
+      expect(() => checkTypesGrant({}, 'someuser'))
+        .toThrow('You do not have the grant to view and edit the metadata');
+    });
+
+    it('returns undefined when fatal=false and no grants', () => {
+      expect(checkTypesGrant({}, 'someuser', false)).toBeUndefined();
+    });
+
+    it('returns undefined when fatal=false and grants is null-ish', () => {
+      expect(checkTypesGrant(null, 'someuser', false)).toBeUndefined();
+      expect(checkTypesGrant(undefined, 'someuser', false)).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles missing username gracefully with fatal=false', () => {
+      expect(checkTypesGrant({}, '', false)).toBeUndefined();
+      expect(checkTypesGrant({}, null, false)).toBeUndefined();
+    });
+
+    it('does not confuse other grant IDs with grant 0', () => {
+      expect(checkTypesGrant({ 1: 'WRITE', 5: 'READ' }, 'someuser', false)).toBeUndefined();
+    });
+
+    it('grant 0 takes precedence regardless of other grants', () => {
+      expect(checkTypesGrant({ 0: 'READ', 1: 'WRITE' }, 'someuser')).toBe('READ');
+    });
+  });
+});

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -2182,24 +2182,65 @@ function legacyXsrfCheck(req, res, next) {
 }
 
 /**
+ * Check Types Grant — authorization gate for type/metadata operations.
+ * Port of PHP Check_Types_Grant() (index.php:967).
+ *
+ * Admin users always get 'WRITE'. Otherwise, checks grants[0] (the type-system
+ * grant at ID 0) for 'READ' or 'WRITE'. When fatal is true and the user lacks
+ * access, throws an object with status 403 so callers can translate it into an
+ * HTTP response.
+ *
+ * @param {Object} grants   - Loaded grants object (from loadGrants)
+ * @param {string} username - Current username
+ * @param {boolean} [fatal=true] - If true, throw on insufficient grant
+ * @returns {string|undefined} 'READ' or 'WRITE', or undefined when non-fatal and no grant
+ */
+function checkTypesGrant(grants, username, fatal = true) {
+  // Admin always has WRITE access — mirrors PHP: if($GLOBALS["GLOBAL_VARS"]["user"] == "admin") return "WRITE"
+  if (username && username.toLowerCase() === 'admin') {
+    return 'WRITE';
+  }
+
+  // Check grant ID 0 (type-system grant) — mirrors PHP: if(isset($GLOBALS["GRANTS"][0]))
+  if (grants && grants[0] !== undefined) {
+    if (grants[0] === 'READ' || grants[0] === 'WRITE') {
+      return grants[0];
+    }
+  }
+
+  // No valid grant found
+  if (fatal) {
+    const err = new Error('You do not have the grant to view and edit the metadata');
+    err.status = 403;
+    throw err;
+  }
+
+  return undefined;
+}
+
+/**
  * Legacy DDL grant check middleware.
  * Checks WRITE grant on types (root level, id=0, t=0) before any type modification.
+ * Uses checkTypesGrant() for PHP-parity authorization.
  *
- * PHP parity: PHP checks DDL grant before any type modification.
+ * PHP parity: PHP calls Check_Types_Grant() before any type modification.
  */
 async function legacyDdlGrantCheck(req, res, next) {
   const db = req.params.db;
   const { grants, username } = req.legacyUser || {};
 
   try {
-    const pool = getPool();
-    const locale = getLocale(req, db);
-    const hasGrant = await checkGrant(pool, db, grants || {}, 0, 0, 'WRITE', username || '');
-    if (!hasGrant) {
-      return res.status(200).json({ error: t9n('insufficient_type_mod', locale) });
+    const grantLevel = checkTypesGrant(grants || {}, username || '', true);
+    if (grantLevel !== 'WRITE') {
+      const locale = getLocale(req, db);
+      return res.status(403).json({ error: t9n('insufficient_type_mod', locale) });
     }
     next();
   } catch (error) {
+    if (error.status === 403) {
+      const locale = getLocale(req, db);
+      return res.status(403).json({ error: error.message });
+    }
     logger.error({ error: error.message, db }, '[legacyDdlGrantCheck] Error');
     const locale = getLocale(req, db);
     return res.status(200).json({ error: t9n('grant_check_failed', locale) });
@@ -13342,6 +13383,7 @@ router.post('/:db/:action', async (req, res) => {
 export {
   legacyAuthMiddleware,
   legacyXsrfCheck,
+  checkTypesGrant,
   legacyDdlGrantCheck,
   resolveBuiltIn,
   recursiveDelete,


### PR DESCRIPTION
## Summary
- `checkTypesGrant(grants, username, fatal)` — pure authorization gate for type/metadata operations
- Admin bypass returns `'WRITE'`, checks `grants[0]` for READ/WRITE
- Refactored `legacyDdlGrantCheck` middleware to use it (eliminates unnecessary async DB query)
- All 13 `_d_*` routes protected via middleware
- 14 unit tests

## PHP parity
Port of `Check_Types_Grant()` from `index.php:967`

## Test plan
- [ ] Admin user gets WRITE access to type editing
- [ ] User with grants[0]='READ' can view but not edit
- [ ] User without grant gets 403
- [ ] Run unit tests

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)