### PR TITLE
port: implement Get_file — template loader with DB override (#307)

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/get-file.test.js
+++ b/backend/monolith/src/api/routes/__tests__/get-file.test.js
@@ -1,0 +1,109 @@
+/**
+ * getFile — Template File Loader tests (Issue #307)
+ *
+ * Port of PHP Get_file() (index.php:1492).
+ * Tests the DB-specific override chain, fatal/non-fatal modes,
+ * and path traversal protection.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { getFile } from '../legacy-compat.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = path.resolve(__dirname, '../../../../public/templates');
+
+describe('getFile', () => {
+  const TEST_DB = '_test_getfile_db';
+  const TEST_FILE = '_test_getfile_template.html';
+  const CUSTOM_CONTENT = '<h1>Custom DB template</h1>';
+  const DEFAULT_CONTENT = '<h1>Default template</h1>';
+
+  beforeAll(async () => {
+    // Create default template
+    await fs.writeFile(path.join(TEMPLATES_DIR, TEST_FILE), DEFAULT_CONTENT, 'utf-8');
+    // Create DB-specific override
+    const customDir = path.join(TEMPLATES_DIR, 'custom', TEST_DB);
+    await fs.mkdir(customDir, { recursive: true });
+    await fs.writeFile(path.join(customDir, TEST_FILE), CUSTOM_CONTENT, 'utf-8');
+  });
+
+  afterAll(async () => {
+    // Clean up test fixtures
+    await fs.unlink(path.join(TEMPLATES_DIR, TEST_FILE)).catch(() => {});
+    await fs.rm(path.join(TEMPLATES_DIR, 'custom', TEST_DB), { recursive: true, force: true });
+  });
+
+  // ── Priority chain ──────────────────────────────────────────────────────
+
+  it('returns DB-specific override when it exists', async () => {
+    const result = await getFile(TEST_DB, TEST_FILE);
+    expect(result).toBe(CUSTOM_CONTENT);
+  });
+
+  it('falls back to default template when no DB override exists', async () => {
+    const result = await getFile('nonexistent_db', TEST_FILE);
+    expect(result).toBe(DEFAULT_CONTENT);
+  });
+
+  it('returns default template when db is null', async () => {
+    const result = await getFile(null, TEST_FILE);
+    expect(result).toBe(DEFAULT_CONTENT);
+  });
+
+  it('returns default template when db is empty string', async () => {
+    const result = await getFile('', TEST_FILE);
+    expect(result).toBe(DEFAULT_CONTENT);
+  });
+
+  // ── Fatal mode (default) ───────────────────────────────────────────────
+
+  it('throws when template not found in fatal mode', async () => {
+    await expect(getFile('anydb', 'nonexistent.html'))
+      .rejects.toThrow('Template nonexistent.html is not found!');
+  });
+
+  it('throws when template not found with fatal=true explicit', async () => {
+    await expect(getFile('anydb', 'nonexistent.html', true))
+      .rejects.toThrow('is not found!');
+  });
+
+  // ── Non-fatal mode ─────────────────────────────────────────────────────
+
+  it('returns false when template not found in non-fatal mode', async () => {
+    const result = await getFile('anydb', 'nonexistent.html', false);
+    expect(result).toBe(false);
+  });
+
+  // ── Input validation ───────────────────────────────────────────────────
+
+  it('throws when file is not provided', async () => {
+    await expect(getFile('db', '')).rejects.toThrow('Set file name!');
+    await expect(getFile('db', null)).rejects.toThrow('Set file name!');
+    await expect(getFile('db', undefined)).rejects.toThrow('Set file name!');
+  });
+
+  // ── Path traversal protection ──────────────────────────────────────────
+
+  it('rejects file paths containing ".."', async () => {
+    await expect(getFile('db', '../etc/passwd'))
+      .rejects.toThrow('Invalid template path');
+  });
+
+  it('rejects absolute file paths', async () => {
+    await expect(getFile('db', '/etc/passwd'))
+      .rejects.toThrow('Invalid template path');
+  });
+
+  it('rejects db names containing ".."', async () => {
+    await expect(getFile('..', 'test.html'))
+      .rejects.toThrow('Invalid database name');
+  });
+
+  it('rejects db names containing "/"', async () => {
+    await expect(getFile('db/../../etc', 'test.html'))
+      .rejects.toThrow('Invalid database name');
+  });
+});

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -8,6 +8,7 @@ import crypto from 'crypto';
 import zlib from 'zlib';
 import path from 'path';
 import fs from 'fs';
+import fsPromises from 'fs/promises';
 import { fileURLToPath } from 'url';
 import logger from '../../utils/logger.js';
 import cookieParser from 'cookie-parser';
@@ -56,6 +57,62 @@ function checkInjection(value) {
     throw new Error(`No SQL clause allowed in search fields. Found: ${match[0]}`);
   }
   return value;
+}
+
+// ── Template File Loader (Issue #307) ────────────────────────────────────────
+
+/**
+ * Port of PHP Get_file() (index.php:1492).
+ * Loads a template file with DB-specific override support.
+ *
+ * Priority chain:
+ *   1. templates/custom/{db}/{file}   (DB-specific override)
+ *   2. templates/{file}               (default template)
+ *
+ * @param {string} db    - Database name (used for custom override directory)
+ * @param {string} file  - Template filename to load
+ * @param {boolean} [fatal=true] - If true, throw when not found; if false, return false
+ * @returns {Promise<string|false>} File contents, or false if non-fatal and not found
+ * @throws {Error} If file is not provided, contains path traversal, or is not found (fatal mode)
+ */
+const TEMPLATES_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../public/templates'
+);
+
+async function getFile(db, file, fatal = true) {
+  if (!file || typeof file !== 'string') {
+    throw new Error('Set file name!');
+  }
+
+  // Path traversal protection: reject ".." or absolute paths
+  if (file.includes('..') || path.isAbsolute(file)) {
+    throw new Error(`Invalid template path: "${file}"`);
+  }
+
+  // Sanitize db as well — it becomes a directory component
+  if (db && (String(db).includes('..') || String(db).includes('/'))) {
+    throw new Error(`Invalid database name: "${db}"`);
+  }
+
+  // 1. Check DB-specific override: templates/custom/{db}/{file}
+  if (db) {
+    const customPath = path.join(TEMPLATES_DIR, 'custom', String(db), file);
+    try {
+      return await fsPromises.readFile(customPath, 'utf-8');
+    } catch {
+      // Fall through to default
+    }
+  }
+
+  // 2. Check default: templates/{file}
+  const defaultPath = path.join(TEMPLATES_DIR, file);
+  try {
+    return await fsPromises.readFile(defaultPath, 'utf-8');
+  } catch {
+    if (!fatal) return false;
+    throw new Error(`Template ${file} is not found!`);
+  }
 }
 
 const router = express.Router();
@@ -13647,6 +13704,7 @@ export {
   isDbVacant,
   updateTokens,
   getCurrentValues,
+  getFile,
 };
 
 export default router;


### PR DESCRIPTION
## Summary
- `getFile(db, file, fatal)` — async template loader using fs/promises
- Priority: `templates/custom/{db}/{file}` → `templates/{file}`
- Path traversal protection (rejects `..`, absolute paths)
- Fatal mode throws, non-fatal returns false
- 12 unit tests

## PHP parity
Port of `Get_file()` from `index.php:1492`

## Test plan
- [ ] DB-specific override loads from custom dir
- [ ] Fallback to default templates dir
- [ ] Path traversal attempts rejected
- [ ] Missing template: fatal throws, non-fatal returns false

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)