### PR TITLE
port: implement Parse_block — recursive template renderer (#302)

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/parse-block.test.js
+++ b/backend/monolith/src/api/routes/__tests__/parse-block.test.js
@@ -1,0 +1,167 @@
+/**
+ * parseBlock — Recursive Template Block Renderer tests (Issue #302)
+ *
+ * Port of PHP Parse_block() (index.php:7148).
+ * Tests placeholder replacement, global vars, recursive child blocks,
+ * multi-row iteration, structural blocks, and depth limiting.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseBlock } from '../legacy-compat.js';
+
+describe('parseBlock', () => {
+  // ── Basic placeholder replacement ──────────────────────────────────────
+
+  it('replaces {colname} placeholders with row data', () => {
+    const blocks = {
+      '&main': { CONTENT: '<p>{name} is {age}</p>' },
+    };
+    const reportData = {
+      '&main': [{ name: 'Alice', age: 30 }],
+    };
+    expect(parseBlock(blocks, '&main', reportData, {}))
+      .toBe('<p>Alice is 30</p>');
+  });
+
+  it('replaces {_global_.varname} with global variables', () => {
+    const blocks = {
+      '&main': { CONTENT: '<h1>{_global_.db}</h1><p>{_global_.user}</p>' },
+    };
+    expect(parseBlock(blocks, '&main', {}, { db: 'mydb', user: 'admin' }))
+      .toBe('<h1>mydb</h1><p>admin</p>');
+  });
+
+  it('replaces both data and global placeholders in same content', () => {
+    const blocks = {
+      '&main': { CONTENT: '{name} on {_global_.db}' },
+    };
+    const reportData = { '&main': [{ name: 'Alice' }] };
+    expect(parseBlock(blocks, '&main', reportData, { db: 'testdb' }))
+      .toBe('Alice on testdb');
+  });
+
+  // ── Multi-row iteration ────────────────────────────────────────────────
+
+  it('concatenates output for multiple data rows', () => {
+    const blocks = {
+      '&main': { CONTENT: '<li>{item}</li>' },
+    };
+    const reportData = {
+      '&main': [{ item: 'A' }, { item: 'B' }, { item: 'C' }],
+    };
+    expect(parseBlock(blocks, '&main', reportData, {}))
+      .toBe('<li>A</li><li>B</li><li>C</li>');
+  });
+
+  // ── Structural blocks (no data) ───────────────────────────────────────
+
+  it('renders block once with global vars when no data rows exist', () => {
+    const blocks = {
+      '&main': { CONTENT: '<div>{_global_.version}</div>' },
+    };
+    expect(parseBlock(blocks, '&main', {}, { version: '1.0' }))
+      .toBe('<div>1.0</div>');
+  });
+
+  it('renders block once preserving unreplaced data placeholders when no data', () => {
+    const blocks = {
+      '&main': { CONTENT: '<p>{unknown}</p>' },
+    };
+    expect(parseBlock(blocks, '&main', {}, {}))
+      .toBe('<p>{unknown}</p>');
+  });
+
+  // ── Child blocks (recursive rendering) ────────────────────────────────
+
+  it('renders child blocks and inserts at {_block_.*} points', () => {
+    const blocks = {
+      '&main': {
+        CONTENT: '<div>{_block_.&main.header}</div><div>{_block_.&main.footer}</div>',
+      },
+      '&main.header': { CONTENT: '<h1>Header</h1>', PARENT: '&main' },
+      '&main.footer': { CONTENT: '<p>Footer</p>', PARENT: '&main' },
+    };
+    expect(parseBlock(blocks, '&main', {}, {}))
+      .toBe('<div><h1>Header</h1></div><div><p>Footer</p></div>');
+  });
+
+  it('renders nested child blocks recursively', () => {
+    const blocks = {
+      '&main': { CONTENT: '{_block_.&main.list}' },
+      '&main.list': { CONTENT: '<ul>{_block_.&main.list.item}</ul>', PARENT: '&main' },
+      '&main.list.item': { CONTENT: '<li>{val}</li>', PARENT: '&main.list' },
+    };
+    const reportData = {
+      '&main.list.item': [{ val: 'X' }, { val: 'Y' }],
+    };
+    expect(parseBlock(blocks, '&main', reportData, {}))
+      .toBe('<ul><li>X</li><li>Y</li></ul>');
+  });
+
+  it('child blocks receive global vars', () => {
+    const blocks = {
+      '&main': { CONTENT: '{_block_.&main.child}' },
+      '&main.child': { CONTENT: 'db={_global_.db}', PARENT: '&main' },
+    };
+    expect(parseBlock(blocks, '&main', {}, { db: 'testdb' }))
+      .toBe('db=testdb');
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────────
+
+  it('returns empty string for missing block path', () => {
+    expect(parseBlock({}, '&missing', {}, {})).toBe('');
+  });
+
+  it('returns empty string when block has null CONTENT', () => {
+    const blocks = { '&main': { CONTENT: null } };
+    expect(parseBlock(blocks, '&main', {}, {})).toBe('');
+  });
+
+  it('handles null values in row data by replacing with empty string', () => {
+    const blocks = { '&main': { CONTENT: '{a}' } };
+    const reportData = { '&main': [{ a: null }] };
+    expect(parseBlock(blocks, '&main', reportData, {})).toBe('');
+  });
+
+  it('handles null global var values by replacing with empty string', () => {
+    const blocks = { '&main': { CONTENT: '{_global_.x}' } };
+    expect(parseBlock(blocks, '&main', {}, { x: null })).toBe('');
+  });
+
+  it('handles numeric zero in row data correctly', () => {
+    const blocks = { '&main': { CONTENT: '{count}' } };
+    const reportData = { '&main': [{ count: 0 }] };
+    expect(parseBlock(blocks, '&main', reportData, {})).toBe('0');
+  });
+
+  it('works with null reportData', () => {
+    const blocks = { '&main': { CONTENT: 'static' } };
+    expect(parseBlock(blocks, '&main', null, {})).toBe('static');
+  });
+
+  it('works with null globalVars', () => {
+    const blocks = { '&main': { CONTENT: '{val}' } };
+    const reportData = { '&main': [{ val: 'ok' }] };
+    expect(parseBlock(blocks, '&main', reportData, null)).toBe('ok');
+  });
+
+  // ── Depth limit ────────────────────────────────────────────────────────
+
+  it('throws when recursion depth exceeds MAX_PARSE_DEPTH', () => {
+    // Build a chain deeper than 100
+    const blocks = {};
+    let path = '&root';
+    blocks[path] = { CONTENT: '' };
+    for (let i = 0; i < 102; i++) {
+      const child = path + '.c';
+      blocks[path].CONTENT = `{_block_.${child}}`;
+      blocks[child] = { CONTENT: '', PARENT: path };
+      path = child;
+    }
+    blocks[path].CONTENT = 'leaf';
+
+    expect(() => parseBlock(blocks, '&root', {}, {}))
+      .toThrow(/maximum recursion depth/);
+  });
+});

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -634,6 +634,99 @@ function localize(text, locale) {
 }
 
 /**
+ * Port of PHP Parse_block() (index.php:7148).
+ *
+ * Recursively renders a template block tree (produced by makeTree / issue #301)
+ * by substituting placeholder tokens with data values, global variables, and
+ * recursively rendered child blocks.
+ *
+ * PHP globals mapped to function parameters:
+ *   $blocks      -> blocks      (flat dict keyed by dot-paths, each with CONTENT / PARENT)
+ *   $REPORT_DATA -> reportData  (dict keyed by block path -> array of row objects)
+ *   $CUR_VARS    -> (local per-row binding)
+ *
+ * @param {object}  blocks      - Block tree from makeTree (flat dict, dot-path keys)
+ * @param {string}  blockPath   - Current block dot-path (e.g. "&main" or "&main.detail")
+ * @param {object}  reportData  - Dataset rows keyed by block path
+ * @param {object}  globalVars  - Global template variables (db, user, token, etc.)
+ * @param {number}  [depth=0]   - Current recursion depth (infinite-loop guard)
+ * @returns {string} Rendered HTML for this block (all iterations concatenated)
+ */
+const MAX_PARSE_DEPTH = 100;
+
+function parseBlock(blocks, blockPath, reportData, globalVars, depth = 0) {
+  if (depth > MAX_PARSE_DEPTH) {
+    throw new Error(
+      `Parse_block: maximum recursion depth (${MAX_PARSE_DEPTH}) exceeded at "${blockPath}"`
+    );
+  }
+
+  const block = blocks[blockPath];
+  if (!block || block.CONTENT == null) {
+    return '';
+  }
+
+  // 1. Get data rows for this block from reportData
+  const rows = (reportData && reportData[blockPath]) || [];
+
+  // 2. Identify child blocks — any block whose PARENT equals this blockPath
+  const childPaths = Object.keys(blocks).filter(
+    (key) => blocks[key].PARENT === blockPath
+  );
+
+  // If there are no data rows, render the block once with just global vars
+  // (structural / layout blocks that don't correspond to a query).
+  const iterations = rows.length > 0 ? rows : [{}];
+
+  let output = '';
+
+  for (const row of iterations) {
+    // Start with the raw block content
+    let content = block.CONTENT;
+
+    // 2a. Replace {colname} data placeholders from the current row.
+    //     PHP does this via str_replace on CUR_VARS keys.
+    //     We match {word} tokens but skip reserved namespaces (_global_, _block_).
+    content = content.replace(/\{([^{}]+)\}/g, (match, key) => {
+      // Skip namespace-prefixed placeholders — handled separately
+      if (key.startsWith('_global_.') || key.startsWith('_block_.')) {
+        return match;
+      }
+      // Replace with row value if present, otherwise leave placeholder
+      if (row && Object.prototype.hasOwnProperty.call(row, key)) {
+        const val = row[key];
+        return val != null ? String(val) : '';
+      }
+      return match;
+    });
+
+    // 2b. Replace {_global_.varname} with global variables
+    if (globalVars) {
+      content = content.replace(/\{_global_\.([^{}]+)\}/g, (match, varName) => {
+        if (Object.prototype.hasOwnProperty.call(globalVars, varName)) {
+          const val = globalVars[varName];
+          return val != null ? String(val) : '';
+        }
+        return match;
+      });
+    }
+
+    // 2c. Recursively render child blocks and insert at {_block_.childpath} points
+    for (const childPath of childPaths) {
+      const childHtml = parseBlock(
+        blocks, childPath, reportData, globalVars, depth + 1
+      );
+      const insertionPoint = `{_block_.${childPath}}`;
+      content = content.split(insertionPoint).join(childHtml);
+    }
+
+    output += content;
+  }
+
+  return output;
+}
+
+/**
  * Render main.html template with PHP-style global variables.
  * PHP replaces {_global_.xxx} placeholders before serving the template.
  */
@@ -13706,6 +13799,7 @@ export {
   getCurrentValues,
   getFile,
   makeTree,
+  parseBlock,
 };
 
 export default router;


### PR DESCRIPTION
## Summary
- `parseBlock(blocks, blockPath, reportData, globalVars, depth)` — recursive template block renderer
- Replaces `{colname}` with row data, `{_global_.varname}` with globals
- Recursively renders child blocks at `{_block_.childpath}` insertion points
- Multi-row iteration for data-bound blocks
- Structural blocks (no data) render once with globals only
- Depth guard at 100 levels
- 17 unit tests

## PHP parity
Port of `Parse_block()` from `index.php:7148`. Paired with `Make_tree` (#301) to form the complete template engine.

## Test plan
- [ ] Simple placeholder replacement
- [ ] Global variable replacement
- [ ] Nested block rendering
- [ ] Multi-row iteration
- [ ] Structural blocks without data
- [ ] Depth limit prevents infinite recursion

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)