### PR TITLE
fix: add createLogger mock for execSql import

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
+++ b/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
@@ -63,6 +63,12 @@ vi.mock('../../../utils/logger.js', () => ({
     warn: vi.fn(),
     debug: vi.fn(),
   },
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
 }));
 
 // ─── import router AFTER mocks ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixed `legacy-compat.test.js` import failure caused by missing `createLogger` mock
- `execSql.js` (#309) imports `createLogger` from `logger.js`, but the test mock didn't provide it
- Added `createLogger` named export returning stubbed child logger
- Result: 0/110 → 61 passed (49 remaining are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)