### PR TITLE
feat: wlog/trace — per-database SQL audit and debug trace

### DIFF
--- a/backend/monolith/src/utils/execSql.js
+++ b/backend/monolith/src/utils/execSql.js
@@ -3,6 +3,7 @@
 
 import { performance } from 'node:perf_hooks';
 import { createLogger } from './logger.js';
+import { wlog, trace } from './wlog.js';
 
 const sqlLogger = createLogger('sql');
 
@@ -100,9 +101,16 @@ export async function execSql(pool, sql, params = [], options = {}) {
       logEntry.insertId = insertId;
     }
     sqlLogger.info(logEntry, 'sql-audit');
+
+    // Per-database file log (PHP: wlog)
+    if (db) {
+      const wlogMsg = `${username}@${ip}[${timing.toFixed(4)}]${sql};[${label}]`;
+      wlog(db, wlogMsg, 'sql');
+    }
   }
 
   // Trace logging for all queries (PHP: trace)
+  trace(`[${timing.toFixed(4)}] ${sql}${label ? ` [${label}]` : ''}`);
   sqlLogger.debug({
     timing: timing.toFixed(4),
     sql,

--- a/backend/monolith/src/utils/wlog.js
+++ b/backend/monolith/src/utils/wlog.js
@@ -1,0 +1,80 @@
+// wlog.js — Per-database SQL audit log + debug trace accumulator (Issue #309)
+// Port of PHP wlog() and trace() functions.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const LOG_DIR = process.env.LOG_DIR || path.resolve('backend/monolith/logs');
+
+// Ensure log directory exists once at startup
+try {
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+} catch {
+  // Silently ignore — appendFile will fail later with a clear error
+}
+
+/**
+ * Format current date as YYYY-MM-DD HH:MM:SS (matching PHP date("Y-m-d H:i:s")).
+ * @returns {string}
+ */
+function formatDate() {
+  const d = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  return (
+    d.getFullYear() + '-' +
+    pad(d.getMonth() + 1) + '-' +
+    pad(d.getDate()) + ' ' +
+    pad(d.getHours()) + ':' +
+    pad(d.getMinutes()) + ':' +
+    pad(d.getSeconds())
+  );
+}
+
+/**
+ * Append a timestamped line to `logs/{db}_{type}.log`.
+ * Non-blocking — fire-and-forget; errors are logged to stderr.
+ *
+ * @param {string} db   - Database name (becomes part of the filename)
+ * @param {string} msg  - Log message
+ * @param {string} [type='sql'] - Log type suffix
+ */
+export function wlog(db, msg, type = 'sql') {
+  const file = path.join(LOG_DIR, `${db}_${type}.log`);
+  const line = `${formatDate()} ${msg}\n`;
+  fs.appendFile(file, line, (err) => {
+    if (err) {
+      process.stderr.write(`wlog write error (${file}): ${err.message}\n`);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Trace accumulator — collects debug messages for the current request.
+// In a multi-request environment, attach traceStore to each req object
+// or use AsyncLocalStorage. For now, a simple module-level accumulator.
+// ---------------------------------------------------------------------------
+
+let _trace = '';
+
+/**
+ * Append a debug trace message (PHP: $GLOBALS["trace"] .= $msg . "<br>\n").
+ * @param {string} msg
+ */
+export function trace(msg) {
+  _trace += msg + '<br>\n';
+}
+
+/**
+ * Return accumulated trace output.
+ * @returns {string}
+ */
+export function getTrace() {
+  return _trace;
+}
+
+/**
+ * Clear the trace accumulator (call at start of each request).
+ */
+export function resetTrace() {
+  _trace = '';
+}


### PR DESCRIPTION
## Summary
- New `utils/wlog.js` with per-database file logging
- `wlog(db, msg, type)` — appends to `logs/{db}_{type}.log` (non-blocking fs.appendFile)
- `trace(msg)` / `getTrace()` / `resetTrace()` — debug trace accumulator
- Integrated into `execSql.js`: mutating queries → wlog, all queries → trace
- Format: `YYYY-MM-DD HH:MM:SS user@ip[timing]sql;[label]`
- Log dir from LOG_DIR env var, default `backend/monolith/logs/`

## PHP parity
Port of `wlog()` (index.php) and `trace()` per-database SQL audit logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)