### PR TITLE
fix: use AsyncLocalStorage for request-scoped queryStats

### DIFF
--- a/backend/monolith/src/utils/__tests__/execSql.test.js
+++ b/backend/monolith/src/utils/__tests__/execSql.test.js
@@ -5,7 +5,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { execSql, queryStats } from '../execSql.js';
+import {
+  execSql,
+  queryStats,
+  queryStatsStorage,
+  runWithQueryStats,
+  getQueryStats,
+} from '../execSql.js';
 
 /** Helper: create a mock pool whose .query() resolves with given data. */
 function mockPool(result, fields = []) {
@@ -88,5 +94,112 @@ describe('execSql — query wrapper', () => {
     await execSql(pool, 'SELECT * FROM t WHERE id = ? AND val = ?', [5, 'x']);
 
     expect(pool.query).toHaveBeenCalledWith('SELECT * FROM t WHERE id = ? AND val = ?', [5, 'x']);
+  });
+});
+
+describe('execSql — request-scoped queryStats (AsyncLocalStorage)', () => {
+  beforeEach(() => queryStats.reset());
+
+  it('getQueryStats() returns module-level stats outside of runWithQueryStats', () => {
+    expect(getQueryStats()).toBe(queryStats);
+  });
+
+  it('getQueryStats() returns scoped store inside runWithQueryStats', async () => {
+    await runWithQueryStats(async () => {
+      const stats = getQueryStats();
+      expect(stats).not.toBe(queryStats);
+      expect(stats).toHaveProperty('count', 0);
+      expect(stats).toHaveProperty('totalTime', 0);
+    });
+  });
+
+  it('execSql increments scoped stats inside runWithQueryStats', async () => {
+    const pool = mockPool([]);
+
+    const scopedStats = await runWithQueryStats(async () => {
+      await execSql(pool, 'SELECT 1');
+      await execSql(pool, 'SELECT 2');
+      await execSql(pool, 'SELECT 3');
+      return getQueryStats();
+    });
+
+    expect(scopedStats.count).toBe(3);
+    expect(scopedStats.totalTime).toBeGreaterThanOrEqual(0);
+    // Module-level stats should remain untouched
+    expect(queryStats.count).toBe(0);
+    expect(queryStats.totalTime).toBe(0);
+  });
+
+  it('falls back to module-level stats outside runWithQueryStats', async () => {
+    const pool = mockPool([]);
+
+    await execSql(pool, 'SELECT 1');
+
+    expect(queryStats.count).toBe(1);
+  });
+
+  it('concurrent requests have isolated stats', async () => {
+    // Simulate two concurrent requests with interleaved queries
+    const pool = mockPool([]);
+
+    const request1 = runWithQueryStats(async () => {
+      await execSql(pool, 'SELECT 1');
+      // Yield to let request2 interleave
+      await new Promise((r) => setTimeout(r, 5));
+      await execSql(pool, 'SELECT 2');
+      await execSql(pool, 'SELECT 3');
+      return getQueryStats();
+    });
+
+    const request2 = runWithQueryStats(async () => {
+      await execSql(pool, 'SELECT a');
+      await new Promise((r) => setTimeout(r, 5));
+      await execSql(pool, 'SELECT b');
+      return getQueryStats();
+    });
+
+    const [stats1, stats2] = await Promise.all([request1, request2]);
+
+    // Each request sees only its own queries
+    expect(stats1.count).toBe(3);
+    expect(stats2.count).toBe(2);
+
+    // Module-level stats unaffected
+    expect(queryStats.count).toBe(0);
+  });
+
+  it('many concurrent requests all stay isolated', async () => {
+    const pool = mockPool([]);
+    const NUM_REQUESTS = 20;
+
+    const promises = Array.from({ length: NUM_REQUESTS }, (_, i) =>
+      runWithQueryStats(async () => {
+        const numQueries = i + 1;
+        for (let q = 0; q < numQueries; q++) {
+          await execSql(pool, `SELECT ${q}`);
+        }
+        return { expected: numQueries, actual: getQueryStats().count };
+      }),
+    );
+
+    const results = await Promise.all(promises);
+
+    for (const { expected, actual } of results) {
+      expect(actual).toBe(expected);
+    }
+
+    // Module-level stats should be untouched
+    expect(queryStats.count).toBe(0);
+  });
+
+  it('queryStatsStorage is an AsyncLocalStorage instance', () => {
+    expect(queryStatsStorage).toBeDefined();
+    expect(typeof queryStatsStorage.run).toBe('function');
+    expect(typeof queryStatsStorage.getStore).toBe('function');
+  });
+
+  it('runWithQueryStats returns the value from the callback', async () => {
+    const result = await runWithQueryStats(async () => 'hello');
+    expect(result).toBe('hello');
   });
 });

--- a/backend/monolith/src/utils/execSql.js
+++ b/backend/monolith/src/utils/execSql.js
@@ -2,6 +2,7 @@
 // Wraps pool.query() with error handling, timing, audit logging, and query counting.
 
 import { performance } from 'node:perf_hooks';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createLogger } from './logger.js';
 
 const sqlLogger = createLogger('sql');
@@ -14,9 +15,16 @@ const sqlLogger = createLogger('sql');
 const MUTATING_SQL_RE = /^\s*(INSERT|UPDATE|DELETE|REPLACE|ALTER|DROP|CREATE|TRUNCATE)\b/i;
 
 /**
- * Per-request query statistics.
- * In a real per-request lifecycle these would live on req/res locals;
- * for now we expose a simple counter object that callers can reset per request.
+ * AsyncLocalStorage instance for request-scoped query statistics.
+ * Each HTTP request runs inside its own storage context so counters
+ * are isolated and never interleave between concurrent requests.
+ */
+export const queryStatsStorage = new AsyncLocalStorage();
+
+/**
+ * Module-level fallback query statistics for non-request contexts
+ * (e.g. CLI scripts, tests that don't use runWithQueryStats).
+ * Kept for backwards compatibility.
  */
 export const queryStats = {
   count: 0,
@@ -27,6 +35,30 @@ export const queryStats = {
     this.totalTime = 0;
   },
 };
+
+/**
+ * Run a function within an isolated query-stats context.
+ * All execSql() calls inside `fn` will accumulate stats in a
+ * fresh per-invocation object instead of the shared module-level one.
+ *
+ * @param {function} fn - Async (or sync) function to run in the scoped context
+ * @returns {Promise<*>} The return value of `fn`
+ */
+export function runWithQueryStats(fn) {
+  const store = { count: 0, totalTime: 0 };
+  return queryStatsStorage.run(store, fn);
+}
+
+/**
+ * Retrieve the current request's query statistics.
+ * Returns the AsyncLocalStorage store if running inside runWithQueryStats(),
+ * otherwise falls back to the module-level queryStats singleton.
+ *
+ * @returns {{ count: number, totalTime: number }}
+ */
+export function getQueryStats() {
+  return queryStatsStorage.getStore() ?? queryStats;
+}
 
 /**
  * Execute a SQL query with PHP Exec_sql-equivalent behaviour.
@@ -81,8 +113,10 @@ export async function execSql(pool, sql, params = [], options = {}) {
   const timing = performance.now() - t0;
 
   // Query counting (PHP: $GLOBALS["sqls"]++ / $GLOBALS["sql_time"])
-  queryStats.count += 1;
-  queryStats.totalTime += timing;
+  // Prefer request-scoped store; fall back to module-level singleton.
+  const stats = queryStatsStorage.getStore() ?? queryStats;
+  stats.count += 1;
+  stats.totalTime += timing;
 
   // Determine insertId for INSERT statements
   const insertId = rawResult?.insertId ?? null;


### PR DESCRIPTION
## Summary

- Fixes #331 — race condition in `execSql.js` where `queryStats` was a module-level singleton shared across all concurrent requests
- Adds `AsyncLocalStorage`-based request-scoped stats via `runWithQueryStats(fn)` and `getQueryStats()`
- Keeps module-level `queryStats` as fallback for non-request contexts (backwards compatible)

## Test plan

- [x] All 7 existing tests still pass unchanged
- [x] 8 new tests covering AsyncLocalStorage behavior:
  - `getQueryStats()` returns module-level stats outside of `runWithQueryStats`
  - `getQueryStats()` returns scoped store inside `runWithQueryStats`
  - `execSql` increments scoped stats inside `runWithQueryStats`
  - Falls back to module-level stats outside `runWithQueryStats`
  - Two concurrent requests have fully isolated stats
  - 20 concurrent requests all stay isolated
  - `queryStatsStorage` is a proper AsyncLocalStorage instance
  - `runWithQueryStats` returns callback's value

🤖 Generated with [Claude Code](https://claude.com/claude-code)