### PR TITLE
fix: checkTypesGrant admin case sensitivity, HTTP status, and role prefix

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/check-types-grant.test.js
+++ b/backend/monolith/src/api/routes/__tests__/check-types-grant.test.js
@@ -1,5 +1,5 @@
 /**
- * checkTypesGrant — Unit tests (Issue #297)
+ * checkTypesGrant — Unit tests (Issue #297, #333)
  *
  * Port of PHP Check_Types_Grant() (index.php:967).
  * Authorization gate for type/metadata operations.
@@ -10,7 +10,7 @@ import { checkTypesGrant } from '../legacy-compat.js';
 
 describe('checkTypesGrant', () => {
   describe('admin bypass', () => {
-    it('returns WRITE for admin user regardless of grants', () => {
+    it('returns WRITE for exact "admin" username regardless of grants', () => {
       expect(checkTypesGrant({}, 'admin')).toBe('WRITE');
     });
 
@@ -18,9 +18,12 @@ describe('checkTypesGrant', () => {
       expect(checkTypesGrant({}, 'admin', true)).toBe('WRITE');
     });
 
-    it('returns WRITE for Admin (case-insensitive)', () => {
-      expect(checkTypesGrant({}, 'Admin')).toBe('WRITE');
-      expect(checkTypesGrant({}, 'ADMIN')).toBe('WRITE');
+    it('does NOT bypass for "Admin" or "ADMIN" (case-sensitive, PHP parity)', () => {
+      // PHP uses exact match: $GLOBALS["GLOBAL_VARS"]["user"] == "admin"
+      const resultAdmin = checkTypesGrant({}, 'Admin', false);
+      const resultADMIN = checkTypesGrant({}, 'ADMIN', false);
+      expect(resultAdmin).toBeUndefined();
+      expect(resultADMIN).toBeUndefined();
     });
 
     it('returns WRITE for admin even when grants[0] is READ', () => {
@@ -37,9 +40,12 @@ describe('checkTypesGrant', () => {
       expect(checkTypesGrant({ 0: 'READ' }, 'someuser')).toBe('READ');
     });
 
-    it('throws 403 when grants[0] has invalid value (fatal=true)', () => {
-      expect(() => checkTypesGrant({ 0: 'NONE' }, 'someuser', true))
-        .toThrow('You do not have the grant to view and edit the metadata');
+    it('returns error object with status 200 when grants[0] has invalid value (fatal=true)', () => {
+      const result = checkTypesGrant({ 0: 'NONE' }, 'someuser', true);
+      expect(result).toEqual({
+        error: 'You do not have the grant to view and edit the metadata',
+        status: 200,
+      });
     });
 
     it('returns undefined when grants[0] has invalid value (fatal=false)', () => {
@@ -47,20 +53,32 @@ describe('checkTypesGrant', () => {
     });
   });
 
-  describe('no grant', () => {
-    it('throws with status 403 when fatal=true and no grants', () => {
-      try {
-        checkTypesGrant({}, 'someuser', true);
-        expect.fail('Should have thrown');
-      } catch (err) {
-        expect(err.message).toBe('You do not have the grant to view and edit the metadata');
-        expect(err.status).toBe(403);
-      }
+  describe('no grant — fatal (PHP die() parity)', () => {
+    it('returns error object with status 200 when fatal=true and no grants', () => {
+      const result = checkTypesGrant({}, 'someuser', true);
+      expect(result).toEqual({
+        error: 'You do not have the grant to view and edit the metadata',
+        status: 200,
+      });
     });
 
-    it('throws when fatal defaults to true', () => {
-      expect(() => checkTypesGrant({}, 'someuser'))
-        .toThrow('You do not have the grant to view and edit the metadata');
+    it('returns error object when fatal defaults to true', () => {
+      const result = checkTypesGrant({}, 'someuser');
+      expect(result).toHaveProperty('error');
+      expect(result).toHaveProperty('status', 200);
+    });
+
+    it('includes role prefix in error message when role is provided', () => {
+      const result = checkTypesGrant({}, 'someuser', true, 'Manager');
+      expect(result).toEqual({
+        error: '[Manager] You do not have the grant to view and edit the metadata',
+        status: 200,
+      });
+    });
+
+    it('omits role prefix when role is empty', () => {
+      const result = checkTypesGrant({}, 'someuser', true, '');
+      expect(result.error).toBe('You do not have the grant to view and edit the metadata');
     });
 
     it('returns undefined when fatal=false and no grants', () => {

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -2536,18 +2536,19 @@ function legacyXsrfCheck(req, res, next) {
  * Port of PHP Check_Types_Grant() (index.php:967).
  *
  * Admin users always get 'WRITE'. Otherwise, checks grants[0] (the type-system
- * grant at ID 0) for 'READ' or 'WRITE'. When fatal is true and the user lacks
- * access, throws an object with status 403 so callers can translate it into an
- * HTTP response.
+ * grant at ID 0) for 'READ' or 'WRITE'. When fatal is true, returns an error
+ * object with HTTP 200 status and JSON error body (matching PHP's die() behavior).
  *
  * @param {Object} grants   - Loaded grants object (from loadGrants)
  * @param {string} username - Current username
- * @param {boolean} [fatal=true] - If true, throw on insufficient grant
- * @returns {string|undefined} 'READ' or 'WRITE', or undefined when non-fatal and no grant
+ * @param {boolean} [fatal=true] - If true, return error object on insufficient grant
+ * @param {string} [role=''] - Current user role name (included in error message for PHP parity)
+ * @returns {string|{error: string, status: number}|undefined} 'READ' or 'WRITE', error object when fatal, or undefined when non-fatal
  */
-function checkTypesGrant(grants, username, fatal = true) {
+function checkTypesGrant(grants, username, fatal = true, role = '') {
   // Admin always has WRITE access — mirrors PHP: if($GLOBALS["GLOBAL_VARS"]["user"] == "admin") return "WRITE"
-  if (username && username.toLowerCase() === 'admin') {
+  // PHP uses exact match (==) against "admin", no case folding
+  if (username && username === 'admin') {
     return 'WRITE';
   }
 
@@ -2558,11 +2559,10 @@ function checkTypesGrant(grants, username, fatal = true) {
     }
   }
 
-  // No valid grant found
+  // No valid grant found — mirrors PHP die() which returns HTTP 200 with error JSON body
   if (fatal) {
-    const err = new Error('You do not have the grant to view and edit the metadata');
-    err.status = 403;
-    throw err;
+    const rolePrefix = role ? `[${role}] ` : '';
+    return { error: `${rolePrefix}You do not have the grant to view and edit the metadata`, status: 200 };
   }
 
   return undefined;
@@ -2577,20 +2577,20 @@ function checkTypesGrant(grants, username, fatal = true) {
  */
 async function legacyDdlGrantCheck(req, res, next) {
   const db = req.params.db;
-  const { grants, username } = req.legacyUser || {};
+  const { grants, username, role } = req.legacyUser || {};
 
   try {
-    const grantLevel = checkTypesGrant(grants || {}, username || '', true);
+    const grantLevel = checkTypesGrant(grants || {}, username || '', true, role || '');
+    if (grantLevel && typeof grantLevel === 'object' && grantLevel.error) {
+      // checkTypesGrant returned an error object (PHP die() parity — HTTP 200 with JSON error body)
+      return res.status(200).json({ error: grantLevel.error });
+    }
     if (grantLevel !== 'WRITE') {
       const locale = getLocale(req, db);
       return res.status(403).json({ error: t9n('insufficient_type_mod', locale) });
     }
     next();
   } catch (error) {
-    if (error.status === 403) {
-      const locale = getLocale(req, db);
-      return res.status(403).json({ error: error.message });
-    }
     logger.error({ error: error.message, db }, '[legacyDdlGrantCheck] Error');
     const locale = getLocale(req, db);
     return res.status(200).json({ error: t9n('grant_check_failed', locale) });


### PR DESCRIPTION
## Summary
Fixes #333 — three PHP-parity issues in `checkTypesGrant`:

- **Admin case sensitivity**: Removed `.toLowerCase()` so only exact `"admin"` bypasses authorization (matching PHP's `==` exact comparison)
- **HTTP status change**: Changed from throwing with `err.status = 403` to returning an error object with `status: 200` and JSON error body (matching PHP's `die()` behavior)
- **Missing role prefix**: Added `role` parameter; error message now includes `[role] ` prefix when role is provided (matching PHP's `$GLOBALS["GLOBAL_VARS"]["role"]`)

Also updated `legacyDdlGrantCheck` middleware to handle the new error object return format.

## Test plan
- [x] Only exact `"admin"` gets WRITE bypass (not `"Admin"` or `"ADMIN"`)
- [x] Fatal denial returns `{ error, status: 200 }` object instead of throwing
- [x] Role prefix included in error message when role is provided
- [x] Role prefix omitted when role is empty
- [x] All 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)