### PR TITLE
fix: document checkInjection expanded keyword list, add strictMode

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/sql-injection-guards.test.js
+++ b/backend/monolith/src/api/routes/__tests__/sql-injection-guards.test.js
@@ -122,7 +122,7 @@ describe('checkInjection', () => {
     expect(() => checkInjection('DROP table')).toThrow('No SQL clause allowed');
   });
 
-  it('requires word boundaries (no false positives)', () => {
+  it('requires word boundaries (no false positives on substrings)', () => {
     // "from" inside a word should not trigger
     expect(checkInjection('information')).toBe('information');
     // "select" inside a word should not trigger
@@ -131,6 +131,73 @@ describe('checkInjection', () => {
     expect(checkInjection('timetable')).toBe('timetable');
     // "update" inside a word
     expect(checkInjection('autoupdate')).toBe('autoupdate');
+    // "where" inside a word
+    expect(checkInjection('somewhere')).toBe('somewhere');
+    expect(checkInjection('anywhere')).toBe('anywhere');
+    // "union" inside a word
+    expect(checkInjection('reunion')).toBe('reunion');
+    expect(checkInjection('communion')).toBe('communion');
+    // "create" inside a word
+    expect(checkInjection('recreate')).toBe('recreate');
+    // "delete" inside a word
+    expect(checkInjection('undelete')).toBe('undelete');
+    // "into" inside a word
+    expect(checkInjection('Manitowoc')).toBe('Manitowoc');
+    // "drop" inside a word
+    expect(checkInjection('raindrop')).toBe('raindrop');
+    expect(checkInjection('droplet')).toBe('droplet');
+    // "alter" inside a word
+    expect(checkInjection('alternatively')).toBe('alternatively');
+    // "exec" inside a word
+    expect(checkInjection('executor')).toBe('executor');
+    // "insert" inside a word
+    expect(checkInjection('reinserted')).toBe('reinserted');
+    // "truncate" inside a word
+    expect(checkInjection('untruncated')).toBe('untruncated');
+  });
+
+  it('detects all 15 expanded keywords as whole words', () => {
+    const keywords = [
+      'SELECT', 'INSERT', 'UPDATE', 'DELETE', 'DROP',
+      'ALTER', 'UNION', 'FROM', 'TABLE', 'WHERE',
+      'INTO', 'EXEC', 'EXECUTE', 'CREATE', 'TRUNCATE',
+    ];
+    for (const kw of keywords) {
+      expect(() => checkInjection(`test ${kw} something`)).toThrow('No SQL clause allowed');
+    }
+  });
+
+  it('is case-insensitive for all keywords', () => {
+    const keywords = [
+      'select', 'INSERT', 'UpDaTe', 'dElEtE', 'Drop',
+      'aLtEr', 'Union', 'from', 'TABLE', 'Where',
+      'iNtO', 'exec', 'Execute', 'CREATE', 'truncate',
+    ];
+    for (const kw of keywords) {
+      expect(() => checkInjection(kw)).toThrow('No SQL clause allowed');
+    }
+  });
+
+  describe('strictMode (PHP-compatible 3-keyword list)', () => {
+    it('blocks the original PHP keywords: FROM, SELECT, TABLE', () => {
+      expect(() => checkInjection('FROM users', { strictMode: true })).toThrow('No SQL clause allowed');
+      expect(() => checkInjection('SELECT *', { strictMode: true })).toThrow('No SQL clause allowed');
+      expect(() => checkInjection('TABLE foo', { strictMode: true })).toThrow('No SQL clause allowed');
+    });
+
+    it('allows keywords not in the PHP 3-keyword list', () => {
+      expect(checkInjection('DELETE something', { strictMode: true })).toBe('DELETE something');
+      expect(checkInjection('DROP something', { strictMode: true })).toBe('DROP something');
+      expect(checkInjection('UNION something', { strictMode: true })).toBe('UNION something');
+      expect(checkInjection('WHERE something', { strictMode: true })).toBe('WHERE something');
+      expect(checkInjection('INSERT something', { strictMode: true })).toBe('INSERT something');
+      expect(checkInjection('UPDATE something', { strictMode: true })).toBe('UPDATE something');
+    });
+
+    it('defaults to expanded list when strictMode is not set', () => {
+      expect(() => checkInjection('DELETE something')).toThrow('No SQL clause allowed');
+      expect(() => checkInjection('UNION something')).toThrow('No SQL clause allowed');
+    });
   });
 
   it('returns non-string values unchanged', () => {

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -40,19 +40,48 @@ function sanitizeIdentifier(name) {
   return `\`${name}\``;
 }
 
+// PHP's original checkInjection (index.php:617) blocks only 3 keywords:
+//   FROM, SELECT, TABLE
+// The Node port intentionally expands this to 15 keywords as defense-in-depth
+// security hardening. The broader list protects against a wider range of SQL
+// injection patterns (e.g. UNION-based, stacked queries, DDL attacks).
+//
+// Tradeoff: the expanded list increases false-positive risk for legitimate
+// search values that happen to contain whole words like "where", "union",
+// "create", etc. Word-boundary matching (\b) mitigates this — substrings
+// inside longer words (e.g. "timetable", "autoupdate") are NOT flagged.
+// If false positives arise, callers can pass strictMode=true to fall back
+// to the original PHP 3-keyword list.
+
+/** @type {RegExp} Expanded 15-keyword SQL injection pattern (Node hardening) */
+const SQL_KEYWORDS_EXPANDED_RE = /\b(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|UNION|FROM|TABLE|WHERE|INTO|EXEC|EXECUTE|CREATE|TRUNCATE)\b/i;
+
+/** @type {RegExp} Original PHP 3-keyword SQL injection pattern */
+const SQL_KEYWORDS_STRICT_RE = /\b(FROM|SELECT|TABLE)\b/i;
+
 /**
  * Check user-supplied search values for SQL injection attempts.
  * Port of PHP checkInjection() (index.php:617) with expanded keyword list.
  *
+ * The PHP original checks only 3 SQL keywords: `FROM`, `SELECT`, `TABLE`.
+ * This Node port intentionally expands the list to 15 keywords for broader
+ * defense-in-depth protection. All matching is word-boundary delimited to
+ * avoid false positives on substrings (e.g. "information" won't match "from").
+ *
  * @param {string} value - The user-supplied value to check
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.strictMode=false] - When true, use the original
+ *   PHP 3-keyword list (FROM, SELECT, TABLE) for backward compatibility.
+ *   Useful when the expanded list causes false positives on legitimate values.
  * @returns {string} The original value if safe
  * @throws {Error} If a SQL keyword is detected
  */
-function checkInjection(value) {
+function checkInjection(value, options) {
   if (typeof value !== 'string') return value;
-  // Match whole SQL keywords (word-boundary delimited, case-insensitive)
-  const SQL_KEYWORDS_RE = /\b(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|UNION|FROM|TABLE|WHERE|INTO|EXEC|EXECUTE|CREATE|TRUNCATE)\b/i;
-  const match = value.match(SQL_KEYWORDS_RE);
+  const re = options && options.strictMode
+    ? SQL_KEYWORDS_STRICT_RE
+    : SQL_KEYWORDS_EXPANDED_RE;
+  const match = value.match(re);
   if (match) {
     throw new Error(`No SQL clause allowed in search fields. Found: ${match[0]}`);
   }


### PR DESCRIPTION
## Summary

Closes #337

- Added JSDoc and inline comments documenting that the 15-keyword list is an intentional security hardening expansion beyond PHP's original 3-keyword list (`FROM`, `SELECT`, `TABLE`), with explanation of the false-positive tradeoff
- Extracted regex patterns into named constants (`SQL_KEYWORDS_EXPANDED_RE`, `SQL_KEYWORDS_STRICT_RE`) for clarity
- Added `options.strictMode` parameter that falls back to the original PHP 3-keyword list for backward compatibility when false positives arise
- Added comprehensive tests: all 15 keywords detected, case insensitivity for every keyword, substring false-positive safety for every keyword (e.g. "somewhere" does not trigger "where"), and strictMode behavior

## Test plan

- [x] All 32 tests pass: `cd backend/monolith && npx vitest run src/api/routes/__tests__/sql-injection-guards.test.js`
- [ ] Verify no regressions in existing search functionality
- [ ] Verify strictMode can be used by callers experiencing false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)