### PR TITLE
docs: document isRef PHP-to-Node signature mapping (#336)

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/isRef.test.js
+++ b/backend/monolith/src/api/routes/__tests__/isRef.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { isRef } from '../legacy-compat.js';
+
+describe('isRef', () => {
+  it('returns the reference target type when typ exists in report.refTyp', () => {
+    const report = { id: 1, parentType: 10, refTyp: { '5': 42 } };
+    expect(isRef(report, 5)).toBe(42);
+  });
+
+  it('works when typ is passed as a string', () => {
+    const report = { id: 1, parentType: 10, refTyp: { '5': 42 } };
+    expect(isRef(report, '5')).toBe(42);
+  });
+
+  it('returns false when typ is not in report.refTyp', () => {
+    const report = { id: 1, parentType: 10, refTyp: { '5': 42 } };
+    expect(isRef(report, 99)).toBe(false);
+  });
+
+  it('returns false when report.refTyp is missing', () => {
+    const report = { id: 1, parentType: 10 };
+    expect(isRef(report, 5)).toBe(false);
+  });
+
+  it('returns false when report is null', () => {
+    expect(isRef(null, 5)).toBe(false);
+  });
+
+  it('returns false when report is undefined', () => {
+    expect(isRef(undefined, 5)).toBe(false);
+  });
+
+  it('returns 0 (falsy but not false) when refTyp value is 0', () => {
+    const report = { id: 1, parentType: 10, refTyp: { '7': 0 } };
+    // The value exists so it should be returned, even though it is 0
+    expect(isRef(report, 7)).toBe(0);
+  });
+
+  it('handles multiple entries in refTyp', () => {
+    const report = {
+      id: 1,
+      parentType: 10,
+      refTyp: { '3': 100, '5': 200, '8': 300 },
+    };
+    expect(isRef(report, 3)).toBe(100);
+    expect(isRef(report, 5)).toBe(200);
+    expect(isRef(report, 8)).toBe(300);
+    expect(isRef(report, 99)).toBe(false);
+  });
+});

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -10829,16 +10829,38 @@ async function compileReport(pool, db, reportId) {
 /**
  * Check whether a given type is a reference type within a compiled report.
  *
- * PHP equivalent (index.php:1750):
- *   function isRef($id, $par, $typ) {
- *     if(isset($GLOBALS["STORED_REPS"][$id]["ref_typ"][$typ]))
- *       return $GLOBALS["STORED_REPS"][$id]["ref_typ"][$typ];
- *     return false;
- *   }
+ * ### Signature mapping (PHP 3-param → Node 2-param)
  *
- * @param {object} report - compiled report object (from compileReport)
- * @param {number|string} typ - type ID to check
- * @returns {number|false} the reference target type ID, or false
+ * PHP signature (index.php:1750):
+ * ```php
+ * function isRef($id, $par, $typ) {
+ *   if(isset($GLOBALS["STORED_REPS"][$id]["ref_typ"][$typ]))
+ *     return $GLOBALS["STORED_REPS"][$id]["ref_typ"][$typ];
+ *   return false;
+ * }
+ * ```
+ *
+ * | PHP param | Node equivalent           | Notes                                    |
+ * |-----------|---------------------------|------------------------------------------|
+ * | `$id`     | `report.id`               | Report ID, embedded in the report object |
+ * | `$par`    | `report.parentType`       | Parent type, embedded in the report obj  |
+ * | `$typ`    | `typ` (2nd param)         | Type ID to look up — kept as-is          |
+ *
+ * **Why the signature changed:** In PHP, `$id` is used to index into the
+ * global `$GLOBALS["STORED_REPS"]` array, and `$par` is available on that
+ * same stored entry but is never used inside the function body. In the Node
+ * port, `compileReport()` returns a self-contained report object that already
+ * carries `id`, `parentType`, and `refTyp` — so the caller passes the report
+ * object directly instead of a bare ID. This collapses the first two PHP
+ * parameters into a single `report` object, reducing the arity from 3 to 2.
+ *
+ * @see {@link https://github.com/unidel2035/integram-standalone/issues/336}
+ *
+ * @param {object} report - Compiled report object (from compileReport).
+ *   Must contain `report.refTyp` — a map of type-ID → reference-target-type.
+ * @param {number|string} typ - Type ID to check for reference status.
+ * @returns {number|false} The reference target type ID, or `false` if `typ`
+ *   is not a reference type in this report.
  */
 function isRef(report, typ) {
   const key = String(typ);


### PR DESCRIPTION
## Summary
- Added comprehensive JSDoc to `isRef()` documenting the PHP 3-param → Node 2-param signature change, with a parameter mapping table explaining how `$id` and `$par` are now encapsulated in the `report` object
- Added 8 unit tests covering: normal lookups, string/number type coercion, missing `refTyp`, null/undefined report, falsy-but-valid values (0), and multi-entry maps

## Test plan
- [x] All 8 `isRef` unit tests pass via `vitest run`
- [ ] Verify JSDoc renders correctly in IDE tooltips

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)