### PR TITLE
fix: conditional Query 2 build and type coercion warning in getCurrentValues

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/get-current-values.test.js
+++ b/backend/monolith/src/api/routes/__tests__/get-current-values.test.js
@@ -52,8 +52,9 @@ vi.mock('../../../utils/t9n.js', () => ({
   getLocale: () => 'en',
 }));
 
-// ─── import getCurrentValues AFTER mocks ─────────────────────────────────────
+// ─── import getCurrentValues and logger AFTER mocks ──────────────────────────
 const { getCurrentValues } = await import('../legacy-compat.js');
+const logger = (await import('../../../utils/logger.js')).default;
 
 // Build a fake pool that delegates to mockQueryFn
 function fakePool() {
@@ -237,6 +238,78 @@ describe('getCurrentValues', () => {
     expect(result.reqTyps).toEqual({});
     expect(result.notNull).toEqual({});
     expect(result.booleans).toEqual({});
+  });
+
+  it('uses simpler Query 2 (no GROUP BY) when no array types exist', async () => {
+    const queries = [];
+    let callIdx = 0;
+    mockQueryFn.mockImplementation(async (sql, ...rest) => {
+      callIdx++;
+      queries.push(sql);
+      if (callIdx === 1) {
+        // No arr_id — no array types
+        return [[
+          { req_id: 200, ref_id: null, attrs: '', ord: 1, base_typ: 3, type_val: 'Name', arr_id: null },
+        ], []];
+      }
+      return [[
+        { id: 500, val: 'Hello', ord: 1, t: 200, arr_num: 1, bt: 3, ref_val: null },
+      ], []];
+    });
+
+    await getCurrentValues(fakePool(), 'testdb', 50, 100, {}, {}, {}, {});
+
+    // Query 2 should NOT contain GROUP BY when no array types exist
+    expect(queries).toHaveLength(2);
+    expect(queries[1]).not.toMatch(/GROUP BY/i);
+  });
+
+  it('uses GROUP BY in Query 2 when array types exist', async () => {
+    const queries = [];
+    let callIdx = 0;
+    mockQueryFn.mockImplementation(async (sql, ...rest) => {
+      callIdx++;
+      queries.push(sql);
+      if (callIdx === 1) {
+        // arr_id=99 means this is an array/multiselect field
+        return [[
+          { req_id: 600, ref_id: null, attrs: ':MULTI:', ord: 1, base_typ: 3, type_val: 'Tags', arr_id: 99 },
+        ], []];
+      }
+      return [[
+        { id: 900, val: 'tag1', ord: 1, t: 99, arr_num: 3, bt: 3, ref_val: null },
+      ], []];
+    });
+
+    await getCurrentValues(fakePool(), 'testdb', 50, 100, {}, {}, {}, {});
+
+    // Query 2 should contain GROUP BY when array types exist
+    expect(queries).toHaveLength(2);
+    expect(queries[1]).toMatch(/GROUP BY/i);
+  });
+
+  it('logs a warning when base type mapping falls back to empty string', async () => {
+    logger.warn.mockClear();
+    let callIdx = 0;
+    mockQueryFn.mockImplementation(async () => {
+      callIdx++;
+      if (callIdx === 1) {
+        // base_typ: 9999 — not in REV_BASE_TYPE, will fall back to ''
+        return [[
+          { req_id: 999, ref_id: null, attrs: '', ord: 1, base_typ: 9999, type_val: 'Unknown', arr_id: null },
+        ], []];
+      }
+      return [[], []];
+    });
+
+    const revBt = {};
+    await getCurrentValues(fakePool(), 'testdb', 50, 100, {}, {}, {}, revBt);
+
+    expect(revBt['999']).toBe('');
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[getCurrentValues] Unknown base type mapping — falling back to empty string',
+      expect.objectContaining({ db: 'testdb', reqKey: '999', baseTypId: 9999 }),
+    );
   });
 
   it('mutates passed-in refTyps, arrTyps, and revBt objects', async () => {

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -6566,7 +6566,11 @@ async function getCurrentValues(pool, db, id, typ, reqs, refTyps, arrTyps, revBt
   }
 
   // ── Query 2: Stored values (PHP GetObjectReqs query 2) ─────────────────
-  const q2 = `SELECT CASE WHEN typs.up=0 THEN 0 ELSE reqs.id  END AS id,
+  // PHP conditionally builds the second SELECT: the COUNT/GROUP BY variant
+  // is only used when array types exist (isset($GLOBALS["ARR_typs"])).
+  const hasArrayTypes = Object.keys(arrTyps).length > 0;
+  const q2 = hasArrayTypes
+    ? `SELECT CASE WHEN typs.up=0 THEN 0 ELSE reqs.id  END AS id,
                 CASE WHEN typs.up=0 THEN 0 ELSE reqs.val END AS val,
                 reqs.ord, typs.id AS t, COUNT(1) AS arr_num,
                 origs.t AS bt, typs.val AS ref_val
@@ -6575,6 +6579,15 @@ async function getCurrentValues(pool, db, id, typ, reqs, refTyps, arrTyps, revBt
          LEFT JOIN ${z} origs ON origs.id = typs.t
          WHERE reqs.up = ?
          GROUP BY val, id, t
+         ORDER BY reqs.ord`
+    : `SELECT CASE WHEN typs.up=0 THEN 0 ELSE reqs.id  END AS id,
+                CASE WHEN typs.up=0 THEN 0 ELSE reqs.val END AS val,
+                reqs.ord, typs.id AS t, 1 AS arr_num,
+                origs.t AS bt, typs.val AS ref_val
+         FROM ${z} reqs
+         JOIN ${z} typs  ON typs.id  = reqs.t
+         LEFT JOIN ${z} origs ON origs.id = typs.t
+         WHERE reqs.up = ?
          ORDER BY reqs.ord`;
   const { rows: storedRows } = await execSql(pool, q2, [id], { label: 'getCurrentValues_q2', db });
 
@@ -6605,7 +6618,13 @@ async function getCurrentValues(pool, db, id, typ, reqs, refTyps, arrTyps, revBt
 
     // Reverse base-type mapping
     const baseTypId = meta.base_typ;
-    revBt[key] = REV_BASE_TYPE[baseTypId] || revBt[baseTypId] || '';
+    const mappedType = REV_BASE_TYPE[baseTypId] || revBt[baseTypId] || '';
+    if (!mappedType) {
+      logger.warn('[getCurrentValues] Unknown base type mapping — falling back to empty string', {
+        db, reqKey: key, baseTypId,
+      });
+    }
+    revBt[key] = mappedType;
 
     if (rows[key] !== undefined) {
       // Direct match — stored value keyed by req type id
@@ -6773,10 +6792,14 @@ router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, (req, res
     const currentRefTyps = {};
     const currentArrTyps = {};
     const currentRevBt = {};
-    const currentValues = await getCurrentValues(
-      pool, db, objectId, objTypeEarly,
-      currentReqs, currentRefTyps, currentArrTyps, currentRevBt
-    );
+    // getCurrentValues mutates the passed-in objects AND returns a clean result
+    // object.  Destructure so every property is available to downstream logic.
+    const { reqs: currentReqVals, reqTyps: currentReqTyps,
+            notNull: currentNotNull, booleans: currentBooleans } =
+      await getCurrentValues(
+        pool, db, objectId, objTypeEarly,
+        currentReqs, currentRefTyps, currentArrTyps, currentRevBt
+      );
 
     // Normal save (not copy)
     // Update value if provided


### PR DESCRIPTION
## Summary
- **Conditional Query 2**: Query 2 now checks whether array types exist before building the SQL. When no array types are present, a simpler query without `GROUP BY`/`COUNT` is used, matching PHP behavior (`isset($GLOBALS["ARR_typs"])`)
- **Type coercion warning**: When the reverse base-type mapping falls back to an empty string (unknown `baseTypId`), a `logger.warn` is emitted instead of silently masking the missing mapping
- **Caller unpacking**: The `_m_save` call site now destructures the return object (`reqs`, `reqTyps`, `notNull`, `booleans`) so all properties are available to downstream logic

Closes #330

## Test plan
- [x] Existing 9 tests continue to pass
- [x] New test: verifies Query 2 omits `GROUP BY` when no array types exist
- [x] New test: verifies Query 2 includes `GROUP BY` when array types exist
- [x] New test: verifies `logger.warn` is called when base type mapping falls back to empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)