### PR TITLE
fix: localize regex behavior drift vs PHP preg_replace

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -726,14 +726,10 @@ function safePath(base, userInput) {
 function localize(text, locale) {
   if (!text || !text.includes('<t9n>')) return text || '';
   const loc = (locale || 'EN').toUpperCase();
-  return text.replace(/<t9n>[\s\S]*?<\/t9n>/g, (match) => {
-    const marker = `[${loc}]`;
-    const idx = match.indexOf(marker);
-    if (idx === -1) return '';
-    const rest = match.slice(idx + marker.length);
-    const m = rest.match(/^([\s\S]*?)(?:\[[A-Z]{2}\]|<\/t9n>)/);
-    return m ? m[1] : '';
-  });
+  const re = new RegExp(`<t9n>(?:(?!</?t9n>).)*?\\[${loc}\\]((?:(?!\\[[A-Z]{2}\\])(?!</t9n>).)*)(?:\\[[A-Z]{2}\\](?:(?!</t9n>).)*)?</t9n>`, 'gs');
+  // Two-pass: extract locale content, then strip any unmatched <t9n> blocks
+  const result = text.replace(re, '$1');
+  return result.replace(/<t9n>.*?<\/t9n>/gs, '');
 }
 
 /**
@@ -13903,6 +13899,7 @@ export {
   getFile,
   makeTree,
   parseBlock,
+  localize,
 };
 
 export default router;

--- a/backend/monolith/src/api/routes/localize.test.js
+++ b/backend/monolith/src/api/routes/localize.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { localize } from './legacy-compat.js';
+
+describe('localize', () => {
+  it('returns text unchanged when no <t9n> tags present', () => {
+    expect(localize('Hello world', 'EN')).toBe('Hello world');
+  });
+
+  it('returns empty string for null/undefined input', () => {
+    expect(localize(null, 'EN')).toBe('');
+    expect(localize(undefined, 'EN')).toBe('');
+    expect(localize('', 'EN')).toBe('');
+  });
+
+  it('extracts correct locale from a basic t9n block', () => {
+    const text = '<t9n>[RU]Привет[EN]Hello</t9n>';
+    expect(localize(text, 'EN')).toBe('Hello');
+    expect(localize(text, 'RU')).toBe('Привет');
+  });
+
+  it('handles three or more locales', () => {
+    const text = '<t9n>[RU]Привет[EN]Hello[DE]Hallo</t9n>';
+    expect(localize(text, 'EN')).toBe('Hello');
+    expect(localize(text, 'RU')).toBe('Привет');
+    expect(localize(text, 'DE')).toBe('Hallo');
+  });
+
+  it('handles multiple t9n blocks in one string', () => {
+    const text = 'Label: <t9n>[RU]Имя[EN]Name</t9n> Value: <t9n>[RU]Значение[EN]Value</t9n>';
+    expect(localize(text, 'EN')).toBe('Label: Name Value: Value');
+    expect(localize(text, 'RU')).toBe('Label: Имя Value: Значение');
+  });
+
+  it('returns empty for missing locale (falls back gracefully)', () => {
+    const text = '<t9n>[RU]Привет[EN]Hello</t9n>';
+    expect(localize(text, 'FR')).toBe('');
+  });
+
+  it('strips unmatched t9n block when locale is missing among other text', () => {
+    const text = 'Before <t9n>[RU]Привет[EN]Hello</t9n> After';
+    expect(localize(text, 'FR')).toBe('Before  After');
+  });
+
+  it('handles multiline content inside t9n blocks', () => {
+    const text = '<t9n>[RU]Строка 1\nСтрока 2[EN]Line 1\nLine 2</t9n>';
+    expect(localize(text, 'EN')).toBe('Line 1\nLine 2');
+    expect(localize(text, 'RU')).toBe('Строка 1\nСтрока 2');
+  });
+
+  it('defaults locale to EN when not provided', () => {
+    const text = '<t9n>[RU]Привет[EN]Hello</t9n>';
+    expect(localize(text, null)).toBe('Hello');
+    expect(localize(text, undefined)).toBe('Hello');
+  });
+
+  it('is case-insensitive for locale parameter', () => {
+    const text = '<t9n>[RU]Привет[EN]Hello</t9n>';
+    expect(localize(text, 'en')).toBe('Hello');
+    expect(localize(text, 'En')).toBe('Hello');
+  });
+
+  it('handles nested brackets in content (non-locale brackets)', () => {
+    const text = '<t9n>[EN]Value [units][RU]Значение [единицы]</t9n>';
+    // The content after [EN] up to [RU] should be extracted
+    expect(localize(text, 'EN')).toBe('Value [units]');
+  });
+
+  it('handles t9n block with surrounding HTML', () => {
+    const text = '<div><t9n>[RU]Привет[EN]Hello</t9n></div>';
+    expect(localize(text, 'EN')).toBe('<div>Hello</div>');
+  });
+
+  it('handles locale as last entry without trailing bracket', () => {
+    const text = '<t9n>[EN]Only English</t9n>';
+    expect(localize(text, 'EN')).toBe('Only English');
+  });
+
+  it('handles empty locale content', () => {
+    const text = '<t9n>[RU][EN]Hello</t9n>';
+    expect(localize(text, 'RU')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaced manual `indexOf()`/`slice()` logic in `localize()` with a single regex using lookaheads, matching PHP `preg_replace` behavior (fixes #335)
- Added `localize` to named exports for testability
- Added comprehensive test suite (14 tests) covering basic extraction, multiple t9n blocks, missing locale fallback, nested brackets, multiline content, case-insensitive locale, and empty content

## Test plan
- [x] All 14 unit tests pass (`npx vitest run src/api/routes/localize.test.js`)
- [ ] Verify locale extraction in staging with real HTML templates containing `<t9n>` blocks
- [ ] Confirm no regressions on report rendering that uses `localize()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)