### PR TITLE
fix: getFile returns empty string on non-fatal failure

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/get-file.test.js
+++ b/backend/monolith/src/api/routes/__tests__/get-file.test.js
@@ -72,9 +72,9 @@ describe('getFile', () => {
 
   // ── Non-fatal mode ─────────────────────────────────────────────────────
 
-  it('returns false when template not found in non-fatal mode', async () => {
+  it('returns empty string when template not found in non-fatal mode', async () => {
     const result = await getFile('anydb', 'nonexistent.html', false);
-    expect(result).toBe(false);
+    expect(result).toBe('');
   });
 
   // ── Input validation ───────────────────────────────────────────────────

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -110,7 +110,7 @@ async function getFile(db, file, fatal = true) {
   try {
     return await fsPromises.readFile(defaultPath, 'utf-8');
   } catch {
-    if (!fatal) return false;
+    if (!fatal) return '';
     throw new Error(`Template ${file} is not found!`);
   }
 }


### PR DESCRIPTION
## Summary
- Changed `getFile()` non-fatal return value from `false` to `''` (empty string) to match PHP `Get_file()` behavior
- Updated test expectation from `toBe(false)` to `toBe('')`
- Verified no callers use `=== false` strict equality checks

Closes #334

## Test plan
- [x] All 12 existing `get-file.test.js` tests pass
- [x] Non-fatal mode test updated to expect `''` instead of `false`
- [x] Callers use truthiness checks (`!result`), so behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)