### PR TITLE
fix: implement 8 missing PHP Parse_block() parity features

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/parse-block.test.js
+++ b/backend/monolith/src/api/routes/__tests__/parse-block.test.js
@@ -1,12 +1,13 @@
 /**
- * parseBlock — Recursive Template Block Renderer tests (Issue #302)
+ * parseBlock — Recursive Template Block Renderer tests (Issue #302, #328)
  *
  * Port of PHP Parse_block() (index.php:7148).
  * Tests placeholder replacement, global vars, recursive child blocks,
- * multi-row iteration, structural blocks, and depth limiting.
+ * multi-row iteration, structural blocks, depth limiting, and all
+ * 8 PHP parity features from issue #328.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { parseBlock } from '../legacy-compat.js';
 
 describe('parseBlock', () => {
@@ -163,5 +164,313 @@ describe('parseBlock', () => {
 
     expect(() => parseBlock(blocks, '&root', {}, {}))
       .toThrow(/maximum recursion depth/);
+  });
+
+  // ══════════════════════════════════════════════════════════════════════
+  // Issue #328 — PHP parity features
+  // ══════════════════════════════════════════════════════════════════════
+
+  // ── Feature 1: _parent_ namespace ──────────────────────────────────────
+
+  describe('_parent_ namespace (feature #1)', () => {
+    it('resolves {_parent_.varname} from parent block row data', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_block_.&main.child}' },
+        '&main.child': { CONTENT: 'parent={_parent_.name}', PARENT: '&main' },
+      };
+      const reportData = {
+        '&main': [{ name: 'Alice' }],
+      };
+      expect(parseBlock(blocks, '&main', reportData, {}))
+        .toBe('parent=Alice');
+    });
+
+    it('resolves _parent_ across multiple parent rows', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_block_.&main.child}' },
+        '&main.child': { CONTENT: '[{_parent_.id}]', PARENT: '&main' },
+      };
+      const reportData = {
+        '&main': [{ id: '1' }, { id: '2' }],
+      };
+      expect(parseBlock(blocks, '&main', reportData, {}))
+        .toBe('[1][2]');
+    });
+
+    it('leaves {_parent_.xxx} unresolved when no parent vars', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_parent_.missing}' },
+      };
+      expect(parseBlock(blocks, '&main', {}, {}))
+        .toBe('{_parent_.missing}');
+    });
+
+    it('resolves _parent_ with null value as empty string', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_block_.&main.child}' },
+        '&main.child': { CONTENT: 'val={_parent_.x}', PARENT: '&main' },
+      };
+      const reportData = { '&main': [{ x: null }] };
+      expect(parseBlock(blocks, '&main', reportData, {}))
+        .toBe('val=');
+    });
+  });
+
+  // ── Feature 2: _request_ namespace ─────────────────────────────────────
+
+  describe('_request_ namespace (feature #2)', () => {
+    it('resolves {_request_.varname} from requestVars option', () => {
+      const blocks = {
+        '&main': { CONTENT: 'page={_request_.page}' },
+      };
+      const options = { requestVars: { page: '3' } };
+      expect(parseBlock(blocks, '&main', {}, {}, 0, options))
+        .toBe('page=3');
+    });
+
+    it('resolves multiple _request_ placeholders', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_request_.sort}:{_request_.order}' },
+      };
+      const options = { requestVars: { sort: 'name', order: 'asc' } };
+      expect(parseBlock(blocks, '&main', {}, {}, 0, options))
+        .toBe('name:asc');
+    });
+
+    it('leaves {_request_.xxx} unresolved when no requestVars', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_request_.missing}' },
+      };
+      expect(parseBlock(blocks, '&main', {}, {}))
+        .toBe('{_request_.missing}');
+    });
+
+    it('_request_ values are HTML-escaped to prevent injection', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_request_.q}' },
+      };
+      const options = { requestVars: { q: '{_global_.db}' } };
+      // The { is escaped to &#123; during substitution, preventing recursive
+      // placeholder resolution. At root level, &#123; is unescaped back to {.
+      // The key point: {_global_.db} is NOT resolved even if db is in globalVars.
+      expect(parseBlock(blocks, '&main', {}, { db: 'LEAKED' }, 0, options))
+        .toBe('{_global_.db}');
+    });
+  });
+
+  // ── Feature 3: resolveBuiltIn() fallback in _global_ ──────────────────
+
+  describe('resolveBuiltIn fallback in _global_ (feature #3)', () => {
+    it('resolves {_global_.date} via resolveBuiltIn when not in globalVars', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_global_.date}' },
+      };
+      // Don't pass 'date' in globalVars — resolveBuiltIn should handle %DATE%
+      const result = parseBlock(blocks, '&main', {}, {});
+      // Should resolve to a date string (dd.mm.yyyy format)
+      expect(result).toMatch(/^\d{2}\.\d{2}\.\d{4}$/);
+    });
+
+    it('prefers explicit globalVars over resolveBuiltIn', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_global_.date}' },
+      };
+      expect(parseBlock(blocks, '&main', {}, { date: 'custom-date' }))
+        .toBe('custom-date');
+    });
+
+    it('leaves unresolvable _global_ placeholders intact', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_global_.nonexistent_xyz}' },
+      };
+      expect(parseBlock(blocks, '&main', {}, {}))
+        .toBe('{_global_.nonexistent_xyz}');
+    });
+  });
+
+  // ── Feature 4: HTML escaping of data values ────────────────────────────
+
+  describe('HTML escaping (feature #4)', () => {
+    it('escapes { in row data values to prevent recursive injection', () => {
+      const blocks = {
+        '&main': { CONTENT: '{val}' },
+      };
+      const reportData = {
+        '&main': [{ val: '{_global_.db}' }],
+      };
+      // The { should be escaped to &#123; during substitution,
+      // then unescaped at root level back to {
+      expect(parseBlock(blocks, '&main', reportData, {}))
+        .toBe('{_global_.db}');
+    });
+
+    it('escaping prevents recursive placeholder resolution', () => {
+      const blocks = {
+        '&main': { CONTENT: '{val}' },
+      };
+      const reportData = {
+        '&main': [{ val: '{_global_.secret}' }],
+      };
+      // Even with secret in globalVars, it should NOT be resolved because
+      // the { was escaped before the _global_ pass
+      const result = parseBlock(blocks, '&main', reportData, { secret: 'LEAKED' });
+      expect(result).toBe('{_global_.secret}');
+      expect(result).not.toContain('LEAKED');
+    });
+
+    it('escapes { in global var values too', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_global_.x}' },
+      };
+      const result = parseBlock(blocks, '&main', {}, { x: 'a{b' });
+      expect(result).toBe('a{b');
+    });
+  });
+
+  // ── Feature 5: Dequeuing iteration model ───────────────────────────────
+
+  describe('dequeuing iteration model (feature #5)', () => {
+    it('processes rows by shifting from queue (array_shift parity)', () => {
+      const blocks = {
+        '&main': { CONTENT: '{n}' },
+      };
+      const reportData = {
+        '&main': [{ n: '1' }, { n: '2' }, { n: '3' }],
+      };
+      expect(parseBlock(blocks, '&main', reportData, {}))
+        .toBe('123');
+    });
+
+    it('does not mutate original reportData arrays', () => {
+      const blocks = {
+        '&main': { CONTENT: '{v}' },
+      };
+      const rows = [{ v: 'a' }, { v: 'b' }];
+      const reportData = { '&main': rows };
+      parseBlock(blocks, '&main', reportData, {});
+      expect(rows).toHaveLength(2);
+    });
+  });
+
+  // ── Feature 6: Early-exit on missing data ──────────────────────────────
+
+  describe('early-exit on missing data (feature #6)', () => {
+    it('stops iteration when a row is missing a placeholder key', () => {
+      const blocks = {
+        '&main': { CONTENT: '{a}-{b}' },
+      };
+      // First row has both keys, second row is missing 'b'
+      const reportData = {
+        '&main': [
+          { a: '1', b: '2' },
+          { a: '3' }, // missing 'b' → early exit
+          { a: '5', b: '6' },
+        ],
+      };
+      // Should render first row, then stop at second (missing 'b')
+      expect(parseBlock(blocks, '&main', reportData, {}))
+        .toBe('1-2');
+    });
+
+    it('renders all rows when all placeholders are satisfied', () => {
+      const blocks = {
+        '&main': { CONTENT: '{x}' },
+      };
+      const reportData = {
+        '&main': [{ x: 'a' }, { x: 'b' }, { x: 'c' }],
+      };
+      expect(parseBlock(blocks, '&main', reportData, {}))
+        .toBe('abc');
+    });
+
+    it('does not early-exit for structural blocks with no row data', () => {
+      const blocks = {
+        '&main': { CONTENT: '<div>{unresolved}</div>' },
+      };
+      // Empty row ({}) means structural block — no early exit
+      expect(parseBlock(blocks, '&main', {}, {}))
+        .toBe('<div>{unresolved}</div>');
+    });
+  });
+
+  // ── Feature 7: Root-level unescape ─────────────────────────────────────
+
+  describe('root-level unescape (feature #7)', () => {
+    it('restores &#123; to { at root level (depth 0)', () => {
+      const blocks = {
+        '&main': { CONTENT: '{val}' },
+      };
+      const reportData = {
+        '&main': [{ val: 'curly{brace' }],
+      };
+      expect(parseBlock(blocks, '&main', reportData, {}))
+        .toBe('curly{brace');
+    });
+
+    it('child blocks do NOT unescape — only root does', () => {
+      // The child renders at depth 1, so &#123; stays encoded until
+      // root merges it and then unescapes.
+      const blocks = {
+        '&main': { CONTENT: '{_block_.&main.child}' },
+        '&main.child': { CONTENT: '{val}', PARENT: '&main' },
+      };
+      const reportData = {
+        '&main.child': [{ val: 'x{y' }],
+      };
+      // Root call (depth 0) should unescape the final output
+      expect(parseBlock(blocks, '&main', reportData, {}))
+        .toBe('x{y');
+    });
+  });
+
+  // ── Feature 8: getBlockData integration ────────────────────────────────
+
+  describe('getBlockData integration (feature #8)', () => {
+    it('calls getBlockData when reportData has no rows for a block', () => {
+      const blocks = {
+        '&main': { CONTENT: '{name}' },
+      };
+      const getBlockData = vi.fn().mockReturnValue([{ name: 'Dynamic' }]);
+      const options = { getBlockData };
+      expect(parseBlock(blocks, '&main', {}, {}, 0, options))
+        .toBe('Dynamic');
+      expect(getBlockData).toHaveBeenCalledWith('&main');
+    });
+
+    it('does NOT call getBlockData when reportData already has rows', () => {
+      const blocks = {
+        '&main': { CONTENT: '{name}' },
+      };
+      const reportData = { '&main': [{ name: 'Static' }] };
+      const getBlockData = vi.fn();
+      const options = { getBlockData };
+      expect(parseBlock(blocks, '&main', reportData, {}, 0, options))
+        .toBe('Static');
+      expect(getBlockData).not.toHaveBeenCalled();
+    });
+
+    it('getBlockData works for child blocks', () => {
+      const blocks = {
+        '&main': { CONTENT: '{_block_.&main.detail}' },
+        '&main.detail': { CONTENT: '{info}', PARENT: '&main' },
+      };
+      const getBlockData = vi.fn((path) => {
+        if (path === '&main.detail') return [{ info: 'loaded' }];
+        return [];
+      });
+      const options = { getBlockData };
+      expect(parseBlock(blocks, '&main', {}, {}, 0, options))
+        .toBe('loaded');
+    });
+
+    it('handles getBlockData returning non-array gracefully', () => {
+      const blocks = {
+        '&main': { CONTENT: 'fallback' },
+      };
+      const getBlockData = vi.fn().mockReturnValue(null);
+      const options = { getBlockData };
+      expect(parseBlock(blocks, '&main', {}, {}, 0, options))
+        .toBe('fallback');
+    });
   });
 });

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -753,11 +753,15 @@ function localize(text, locale) {
  * @param {object}  reportData  - Dataset rows keyed by block path
  * @param {object}  globalVars  - Global template variables (db, user, token, etc.)
  * @param {number}  [depth=0]   - Current recursion depth (infinite-loop guard)
+ * @param {object}  [options={}] - Additional options for PHP parity
+ * @param {object}  [options.requestVars]  - $_GET/$_POST vars for {_request_.xxx} namespace
+ * @param {object}  [options.parentVars]   - Parent block's current row vars for {_parent_.xxx}
+ * @param {Function} [options.getBlockData] - Callback(blockPath) returning array of row objects
  * @returns {string} Rendered HTML for this block (all iterations concatenated)
  */
 const MAX_PARSE_DEPTH = 100;
 
-function parseBlock(blocks, blockPath, reportData, globalVars, depth = 0) {
+function parseBlock(blocks, blockPath, reportData, globalVars, depth = 0, options = {}) {
   if (depth > MAX_PARSE_DEPTH) {
     throw new Error(
       `Parse_block: maximum recursion depth (${MAX_PARSE_DEPTH}) exceeded at "${blockPath}"`
@@ -769,64 +773,152 @@ function parseBlock(blocks, blockPath, reportData, globalVars, depth = 0) {
     return '';
   }
 
-  // 1. Get data rows for this block from reportData
-  const rows = (reportData && reportData[blockPath]) || [];
+  const { requestVars, parentVars, getBlockData } = options;
+
+  // 1. Get data rows for this block from reportData, with getBlockData fallback
+  //    PHP calls Get_block_data() dynamically when data is not pre-populated.
+  let rows = (reportData && reportData[blockPath]) || [];
+  if (rows.length === 0 && typeof getBlockData === 'function') {
+    const dynamicRows = getBlockData(blockPath);
+    if (Array.isArray(dynamicRows)) {
+      rows = dynamicRows;
+    }
+  }
+
+  // Use dequeuing model (array_shift) — PHP uses while(!isset($end)) with array_shift.
+  // Clone the array so we can shift from it without mutating the original.
+  const queue = rows.length > 0 ? [...rows] : null;
 
   // 2. Identify child blocks — any block whose PARENT equals this blockPath
   const childPaths = Object.keys(blocks).filter(
     (key) => blocks[key].PARENT === blockPath
   );
 
-  // If there are no data rows, render the block once with just global vars
-  // (structural / layout blocks that don't correspond to a query).
-  const iterations = rows.length > 0 ? rows : [{}];
-
   let output = '';
 
-  for (const row of iterations) {
-    // Start with the raw block content
-    let content = block.CONTENT;
-
-    // 2a. Replace {colname} data placeholders from the current row.
-    //     PHP does this via str_replace on CUR_VARS keys.
-    //     We match {word} tokens but skip reserved namespaces (_global_, _block_).
-    content = content.replace(/\{([^{}]+)\}/g, (match, key) => {
-      // Skip namespace-prefixed placeholders — handled separately
-      if (key.startsWith('_global_.') || key.startsWith('_block_.')) {
-        return match;
-      }
-      // Replace with row value if present, otherwise leave placeholder
-      if (row && Object.prototype.hasOwnProperty.call(row, key)) {
-        const val = row[key];
-        return val != null ? String(val) : '';
-      }
-      return match;
-    });
-
-    // 2b. Replace {_global_.varname} with global variables
-    if (globalVars) {
-      content = content.replace(/\{_global_\.([^{}]+)\}/g, (match, varName) => {
-        if (Object.prototype.hasOwnProperty.call(globalVars, varName)) {
-          const val = globalVars[varName];
-          return val != null ? String(val) : '';
-        }
-        return match;
-      });
-    }
-
-    // 2c. Recursively render child blocks and insert at {_block_.childpath} points
-    for (const childPath of childPaths) {
-      const childHtml = parseBlock(
-        blocks, childPath, reportData, globalVars, depth + 1
+  // PHP dequeuing model: shift rows one at a time; if no rows, render once with empty row
+  if (queue) {
+    while (queue.length > 0) {
+      const row = queue.shift();
+      const rendered = _renderIteration(
+        block, blocks, blockPath, row, globalVars, childPaths,
+        reportData, depth, options
       );
-      const insertionPoint = `{_block_.${childPath}}`;
-      content = content.split(insertionPoint).join(childHtml);
+      if (rendered === null) break; // early-exit on missing placeholder
+      output += rendered;
     }
+  } else {
+    // Structural / layout blocks with no data — render once
+    const rendered = _renderIteration(
+      block, blocks, blockPath, {}, globalVars, childPaths,
+      reportData, depth, options
+    );
+    if (rendered !== null) {
+      output += rendered;
+    }
+  }
 
-    output += content;
+  // Root-level unescape: restore &#123; → { when processing &main or root block (depth === 0)
+  if (depth === 0) {
+    output = output.replace(/&#123;/g, '{');
   }
 
   return output;
+}
+
+/**
+ * Render a single iteration of a block with the given row data.
+ * Returns null if a data placeholder is missing (early-exit signal).
+ * @private
+ */
+function _renderIteration(
+  block, blocks, blockPath, row, globalVars, childPaths,
+  reportData, depth, options
+) {
+  const { requestVars, parentVars, getBlockData } = options;
+  let content = block.CONTENT;
+  let missingPlaceholder = false;
+
+  // 2a. Replace {colname} data placeholders from the current row.
+  //     Also handles {_parent_.xxx} and {_request_.xxx} namespaces.
+  //     HTML-escape `{` in data values → &#123; to prevent recursive placeholder injection.
+  content = content.replace(/\{([^{}]+)\}/g, (match, key) => {
+    // Skip namespace-prefixed placeholders handled separately
+    if (key.startsWith('_global_.') || key.startsWith('_block_.')) {
+      return match;
+    }
+
+    // {_parent_.varname} — resolve from parent block's variables
+    if (key.startsWith('_parent_.')) {
+      const parentKey = key.slice('_parent_.'.length);
+      if (parentVars && Object.prototype.hasOwnProperty.call(parentVars, parentKey)) {
+        const val = parentVars[parentKey];
+        return val != null ? String(val).replace(/\{/g, '&#123;') : '';
+      }
+      return match;
+    }
+
+    // {_request_.varname} — resolve from $_GET/$_POST equivalent
+    if (key.startsWith('_request_.')) {
+      const reqKey = key.slice('_request_.'.length);
+      if (requestVars && Object.prototype.hasOwnProperty.call(requestVars, reqKey)) {
+        const val = requestVars[reqKey];
+        return val != null ? String(val).replace(/\{/g, '&#123;') : '';
+      }
+      return match;
+    }
+
+    // Replace with row value if present, otherwise signal missing placeholder
+    if (row && Object.prototype.hasOwnProperty.call(row, key)) {
+      const val = row[key];
+      // HTML-escape { in values to prevent recursive placeholder injection
+      return val != null ? String(val).replace(/\{/g, '&#123;') : '';
+    }
+
+    // Early-exit: if row has data (non-empty) but this key is missing, break
+    if (row && Object.keys(row).length > 0) {
+      missingPlaceholder = true;
+    }
+    return match;
+  });
+
+  // Early-exit on missing data placeholder (PHP breaks on first missing)
+  if (missingPlaceholder) {
+    return null;
+  }
+
+  // 2b. Replace {_global_.varname} with global variables, with resolveBuiltIn fallback
+  if (globalVars || true) {
+    content = content.replace(/\{_global_\.([^{}]+)\}/g, (match, varName) => {
+      if (globalVars && Object.prototype.hasOwnProperty.call(globalVars, varName)) {
+        const val = globalVars[varName];
+        return val != null ? String(val).replace(/\{/g, '&#123;') : '';
+      }
+      // BuiltIn() fallback: call resolveBuiltIn for system variables like today, now, etc.
+      const builtInResult = resolveBuiltIn(`%${varName.toUpperCase()}%`, {}, '', 0, '', {});
+      // If resolveBuiltIn resolved it (returned something different from the input), use it
+      if (builtInResult !== `%${varName.toUpperCase()}%`) {
+        return String(builtInResult).replace(/\{/g, '&#123;');
+      }
+      return match;
+    });
+  }
+
+  // 2c. Recursively render child blocks and insert at {_block_.childpath} points
+  //     Pass current row as parentVars so children can use {_parent_.xxx}
+  for (const childPath of childPaths) {
+    const childOptions = {
+      ...options,
+      parentVars: row, // current row becomes parent vars for child blocks
+    };
+    const childHtml = parseBlock(
+      blocks, childPath, reportData, globalVars, depth + 1, childOptions
+    );
+    const insertionPoint = `{_block_.${childPath}}`;
+    content = content.split(insertionPoint).join(childHtml);
+  }
+
+  return content;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #328

- **`_parent_` namespace**: Resolve `{_parent_.varname}` by looking up parent block's current row variables, passed down via `options.parentVars`
- **`_request_` namespace**: Resolve `{_request_.varname}` from `options.requestVars` (represents `$_GET`/`$_POST`)
- **`resolveBuiltIn()` fallback**: When `{_global_.xxx}` is not found in `globalVars`, fall back to `resolveBuiltIn()` for system variables like `%DATE%`, `%TIME%`, etc.
- **HTML escaping**: Escape `{` to `&#123;` in all substituted data values to prevent recursive placeholder injection (template injection risk)
- **Dequeuing iteration model**: Replace simple `for-of` with `shift()`-based while loop matching PHP's `array_shift()` pattern
- **Early-exit on missing data**: Break iteration on first missing placeholder in a data row (PHP parity)
- **Root-level unescape**: Restore `&#123;` back to `{` at depth 0 after all substitution is complete
- **`getBlockData` integration**: Accept optional `getBlockData(blockPath)` callback that dynamically populates block data when `reportData` has no rows

## Test plan

- [x] All 42 tests pass (17 existing + 25 new covering all 8 features)
- [ ] Verify `_parent_` namespace resolves correctly in nested blocks
- [ ] Verify `_request_` namespace injects GET/POST vars without recursive injection
- [ ] Verify `resolveBuiltIn` fallback resolves system macros like `{_global_.date}`
- [ ] Verify HTML escaping prevents template injection attacks
- [ ] Verify early-exit stops on missing placeholder
- [ ] Verify root unescape restores literal braces in final output

🤖 Generated with [Claude Code](https://claude.com/claude-code)