### PR TITLE
fix: wrap all error responses in array for PHP my_die() parity (#350)

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
+++ b/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
@@ -525,7 +525,7 @@ describe('legacyAuthMiddleware', () => {
     await legacyAuthMiddleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    expect(res.json).toHaveBeenCalledWith([{ error: 'Authentication required' }]);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -537,7 +537,7 @@ describe('legacyAuthMiddleware', () => {
     await legacyAuthMiddleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid database' });
+    expect(res.json).toHaveBeenCalledWith([{ error: 'Invalid database' }]);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -553,7 +553,7 @@ describe('legacyAuthMiddleware', () => {
     await legacyAuthMiddleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid or expired token' });
+    expect(res.json).toHaveBeenCalledWith([{ error: 'Invalid or expired token' }]);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -605,7 +605,7 @@ describe('legacyXsrfCheck', () => {
     legacyXsrfCheck(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid or expired CSRF token' });
+    expect(res.json).toHaveBeenCalledWith([{ error: 'Invalid or expired CSRF token' }]);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -874,7 +874,7 @@ describe('Phase 2: middleware wiring', () => {
           .post(`/${DB}/${route}`)
           .send({ _xsrf: 'fake' });
         expect(res.status).toBe(401);
-        expect(res.body.error).toBeDefined();
+        expect(res.body[0].error).toBeDefined();
       });
     }
   });
@@ -896,7 +896,7 @@ describe('Phase 2: middleware wiring', () => {
         .send({ _xsrf: 'wrong-xsrf', val: 'test' });
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ error: 'Invalid or expired CSRF token' });
+      expect(res.body).toEqual([{ error: 'Invalid or expired CSRF token' }]);
     });
   });
 
@@ -913,7 +913,7 @@ describe('Phase 2: middleware wiring', () => {
           .post(`/${DB}/${route}`)
           .send({ _xsrf: 'fake' });
         expect(res.status).toBe(401);
-        expect(res.body.error).toBeDefined();
+        expect(res.body[0].error).toBeDefined();
       });
     }
   });
@@ -932,7 +932,7 @@ describe('Phase 2: middleware wiring', () => {
         const res = await request(app)
           .get(`/${DB}/${route}`);
         expect(res.status).toBe(401);
-        expect(res.body.error).toBeDefined();
+        expect(res.body[0].error).toBeDefined();
       });
     }
   });

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -2489,7 +2489,7 @@ async function legacyAuthMiddleware(req, res, next) {
   const db = req.params.db;
   const locale = getLocale(req, db);
   if (!db || !isValidDbName(db)) {
-    return res.status(401).json({ error: t9n('invalid_database', locale) });
+    return res.status(401).json([{ error: t9n('invalid_database', locale) }]);
   }
 
   const token = extractToken(req, db);
@@ -2582,10 +2582,10 @@ async function legacyAuthMiddleware(req, res, next) {
     }
 
     // No guest user defined — reject
-    return res.status(401).json({ error: t9n(token ? 'invalid_token' : 'auth_required', locale) });
+    return res.status(401).json([{ error: t9n(token ? 'invalid_token' : 'auth_required', locale) }]);
   } catch (error) {
     logger.error({ error: error.message, db }, '[legacyAuthMiddleware] Error');
-    return res.status(401).json({ error: t9n('auth_failed', locale) });
+    return res.status(401).json([{ error: t9n('auth_failed', locale) }]);
   }
 }
 
@@ -2607,7 +2607,7 @@ function legacyXsrfCheck(req, res, next) {
   if (!xsrf || bodyXsrf !== xsrf) {
     // HTTP 200 matching PHP my_die() behavior
     const locale = getLocale(req, req.params.db);
-    return res.status(200).json({ error: t9n('invalid_csrf', locale) });
+    return res.status(200).json([{ error: t9n('invalid_csrf', locale) }]);
   }
 
   next();
@@ -2665,17 +2665,17 @@ async function legacyDdlGrantCheck(req, res, next) {
     const grantLevel = checkTypesGrant(grants || {}, username || '', true, role || '');
     if (grantLevel && typeof grantLevel === 'object' && grantLevel.error) {
       // checkTypesGrant returned an error object (PHP die() parity — HTTP 200 with JSON error body)
-      return res.status(200).json({ error: grantLevel.error });
+      return res.status(200).json([{ error: grantLevel.error }]);
     }
     if (grantLevel !== 'WRITE') {
       const locale = getLocale(req, db);
-      return res.status(403).json({ error: t9n('insufficient_type_mod', locale) });
+      return res.status(403).json([{ error: t9n('insufficient_type_mod', locale) }]);
     }
     next();
   } catch (error) {
     logger.error({ error: error.message, db }, '[legacyDdlGrantCheck] Error');
     const locale = getLocale(req, db);
-    return res.status(200).json({ error: t9n('grant_check_failed', locale) });
+    return res.status(200).json([{ error: t9n('grant_check_failed', locale) }]);
   }
 }
 
@@ -3111,9 +3111,9 @@ router.get('/:db/auth', async (req, res, next) => {
   const { db } = req.params;
   if (!isApiRequest(req)) return next();
   const locale = getLocale(req, db);
-  if (!isValidDbName(db)) return res.status(200).json({ error: t9n('invalid_database_name', locale) });
+  if (!isValidDbName(db)) return res.status(200).json([{ error: t9n('invalid_database_name', locale) }]);
   const token = extractToken(req, db);
-  if (!token) return res.status(200).json({ error: t9n('not_logged', locale) });
+  if (!token) return res.status(200).json([{ error: t9n('not_logged', locale) }]);
   try {
     const pool = getPool();
     const { rows: rows } = await execSql(pool, `SELECT u.id uid, u.val uname, x.val xsrf_val
@@ -3121,13 +3121,13 @@ router.get('/:db/auth', async (req, res, next) => {
        JOIN \`${db}\` tok ON tok.up = u.id AND tok.t = ${TYPE.TOKEN} AND tok.val = ?
        LEFT JOIN \`${db}\` x ON x.up = u.id AND x.t = ${TYPE.XSRF}
        WHERE u.t = ${TYPE.USER} LIMIT 1`, [token], { label: 'get_db_auth_select' });
-    if (rows.length === 0) return res.status(200).json({ error: t9n('not_logged', locale) });
+    if (rows.length === 0) return res.status(200).json([{ error: t9n('not_logged', locale) }]);
     const u = rows[0];
     const xsrf = u.xsrf_val || generateXsrf(token, u.uname || '', db);
     return res.status(200).json({ _xsrf: xsrf, token, id: Number(u.uid), msg: '' });
   } catch (err) {
     logger.error('[GET /:db/auth] DB error', { error: err.message, db });
-    return res.status(200).json({ error: t9n('server_error', locale) });
+    return res.status(200).json([{ error: t9n('server_error', locale) }]);
   }
 });
 
@@ -3140,7 +3140,7 @@ router.all('/:db/auth', async (req, res, next) => {
 
   const locale = getLocale(req, db);
   if (!isValidDbName(db)) {
-    if (isJSON) return res.status(200).json({ error: t9n('invalid_database_name', locale) });
+    if (isJSON) return res.status(200).json([{ error: t9n('invalid_database_name', locale) }]);
     return res.status(400).send(t9n('invalid_database', locale));
   }
 
@@ -3161,7 +3161,7 @@ router.all('/:db/auth', async (req, res, next) => {
 
     if (rows.length === 0) {
       logger.warn('[Legacy SecretAuth] Invalid secret token', { db });
-      if (isJSON) return res.status(200).json({ error: t9n('invalid_secret', locale) });
+      if (isJSON) return res.status(200).json([{ error: t9n('invalid_secret', locale) }]);
       return res.status(401).send(t9n('invalid_secret', locale));
     }
 
@@ -3203,7 +3203,7 @@ router.all('/:db/auth', async (req, res, next) => {
     return res.redirect(String(uri).replace(/[<>"']/g, ''));
   } catch (error) {
     logger.error('[Legacy SecretAuth] Error', { error: error.message, db });
-    if (isJSON) return res.status(200).json({ error: error.message });
+    if (isJSON) return res.status(200).json([{ error: error.message }]);
     return res.status(500).send('Server error');
   }
 });
@@ -3240,7 +3240,7 @@ router.post('/:db/auth', async (req, res, next) => {
   // Validate DB name
   if (!isValidDbName(db)) {
     if (isJSON) {
-      return res.status(200).json({ error: t9n('invalid_database_name', locale) });
+      return res.status(200).json([{ error: t9n('invalid_database_name', locale) }]);
     }
     return res.status(400).send(t9n('invalid_database', locale));
   }
@@ -3259,7 +3259,7 @@ router.post('/:db/auth', async (req, res, next) => {
 
   if (!login || !password) {
     if (isJSON) {
-      return res.status(200).json({ error: t9n('login_password_required', locale) });
+      return res.status(200).json([{ error: t9n('login_password_required', locale) }]);
     }
     return res.status(400).send(t9n('login_password_required', locale));
   }
@@ -3268,7 +3268,7 @@ router.post('/:db/auth', async (req, res, next) => {
     // Check if database exists
     if (!await dbExists(db)) {
       if (isJSON) {
-        return res.status(200).json({ error: `${db} does not exist` });
+        return res.status(200).json([{ error: `${db} does not exist` }]);
       }
       return res.status(404).send(`${db} does not exist`);
     }
@@ -3342,7 +3342,7 @@ router.post('/:db/auth', async (req, res, next) => {
       logger.warn('[Legacy Auth] User not found', { db, login });
       if (isJSON) {
         // PHP: my_die("Wrong credentials...") → HTTP 200 [{"error":"..."}]
-        return res.status(200).json({ error: `Wrong credentials for user ${login} in ${db}. Please send login and password as POST-parameters.` });
+        return res.status(200).json([{ error: `Wrong credentials for user ${login} in ${db}. Please send login and password as POST-parameters.` }]);
       }
       return res.status(401).send('Invalid credentials');
     }
@@ -3398,7 +3398,7 @@ router.post('/:db/auth', async (req, res, next) => {
 
       logger.warn('[Legacy Auth] Password mismatch', { db, login });
       if (isJSON) {
-        return res.status(200).json({ error: `Wrong credentials for user ${login} in ${db}. Please send login and password as POST-parameters.` });
+        return res.status(200).json([{ error: `Wrong credentials for user ${login} in ${db}. Please send login and password as POST-parameters.` }]);
       }
       return res.status(401).send('Invalid credentials');
     }
@@ -3485,7 +3485,7 @@ router.post('/:db/auth', async (req, res, next) => {
     logger.error('[Legacy Auth] Error', { error: error.message, db, login });
 
     if (isJSON) {
-      return res.status(200).json({ error: 'Authentication failed' });
+      return res.status(200).json([{ error: 'Authentication failed' }]);
     }
     return res.status(500).send('Authentication failed');
   }
@@ -3580,7 +3580,7 @@ router.post('/:db/getcode', async (req, res) => {
 
   // PHP validates email format
   if (!u || !/^.+@.+\..+$/.test(u)) {
-    return res.status(200).json({ error: 'invalid user' });
+    return res.status(200).json([{ error: 'invalid user' }]);
   }
 
   try {
@@ -3599,7 +3599,7 @@ router.post('/:db/getcode', async (req, res) => {
     }
   } catch (error) {
     logger.error({ error: error.message, db }, '[Legacy GetCode] Error');
-    return res.status(200).json({ error: 'server error' });
+    return res.status(200).json([{ error: 'server error' }]);
   }
 });
 
@@ -3618,7 +3618,7 @@ router.post('/:db/checkcode', async (req, res) => {
   logger.info({ db, u }, '[Legacy CheckCode] Request');
 
   if (!u || !c || c.length !== 4) {
-    return res.status(200).json({ error: 'invalid data' });
+    return res.status(200).json([{ error: 'invalid data' }]);
   }
 
   try {
@@ -3659,11 +3659,11 @@ router.post('/:db/checkcode', async (req, res) => {
 
       return res.status(200).json({ token: newToken, _xsrf: newXsrf });
     } else {
-      return res.status(200).json({ error: 'user not found' });
+      return res.status(200).json([{ error: 'user not found' }]);
     }
   } catch (error) {
     logger.error({ error: error.message, db }, '[Legacy CheckCode] Error');
-    return res.status(200).json({ error: 'invalid data' });
+    return res.status(200).json([{ error: 'invalid data' }]);
   }
 });
 
@@ -3695,7 +3695,7 @@ router.post('/:db/auth', async (req, res, next) => {
   logger.info({ db, u }, '[Legacy Reset] Password reset request');
 
   if (!u) {
-    if (isJSON) return res.status(200).json({ error: 'Login required' });
+    if (isJSON) return res.status(200).json([{ error: 'Login required' }]);
     return res.redirect(`/${db}`);
   }
 
@@ -3827,7 +3827,7 @@ router.post('/:db/auth', async (req, res, next) => {
     });
   } catch (error) {
     logger.error({ error: error.message, db, u }, '[Legacy Reset] Error');
-    if (isJSON) return res.status(200).json({ error: 'Reset failed' });
+    if (isJSON) return res.status(200).json([{ error: 'Reset failed' }]);
     return res.redirect(`/${db}`);
   }
 });
@@ -3956,7 +3956,7 @@ router.get('/my/google-auth', (req, res) => {
   const clientId = process.env.GOOGLE_CLIENT_ID;
   if (!clientId) {
     logger.error('[Google OAuth] GOOGLE_CLIENT_ID not configured');
-    return res.status(500).json({ error: 'Google OAuth is not configured on this server' });
+    return res.status(500).json([{ error: 'Google OAuth is not configured on this server' }]);
   }
 
   const host = req.get('host') || 'localhost';
@@ -3986,14 +3986,14 @@ router.get('/my/google-auth', (req, res) => {
 router.get('/auth.asp', async (req, res) => {
   const code = req.query.code;
   if (!code) {
-    return res.status(400).json({ error: 'Missing authorization code' });
+    return res.status(400).json([{ error: 'Missing authorization code' }]);
   }
 
   const clientId = process.env.GOOGLE_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
   if (!clientId || !clientSecret) {
     logger.error('[Google OAuth] GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET not configured');
-    return res.status(500).json({ error: 'Google OAuth is not configured on this server' });
+    return res.status(500).json([{ error: 'Google OAuth is not configured on this server' }]);
   }
 
   const host = req.get('host') || 'localhost';
@@ -4021,7 +4021,7 @@ router.get('/auth.asp', async (req, res) => {
 
     if (!tokenData.access_token) {
       logger.error('[Google OAuth] Token exchange failed', { error: tokenData.error, description: tokenData.error_description });
-      return res.status(401).json({ error: 'Google authentication failed', details: tokenData.error_description || tokenData.error });
+      return res.status(401).json([{ error: 'Google authentication failed', details: tokenData.error_description || tokenData.error }]);
     }
 
     // ── Step 2: Retrieve user info ──
@@ -4034,7 +4034,7 @@ router.get('/auth.asp', async (req, res) => {
 
     if (!info.id) {
       logger.error('[Google OAuth] Failed to get user info', { info });
-      return res.status(401).json({ error: 'Authentication error' });
+      return res.status(401).json([{ error: 'Authentication error' }]);
     }
 
     logger.info('[Google OAuth] Got user info', { googleId: info.id, email: info.email, name: info.name });
@@ -4045,7 +4045,7 @@ router.get('/auth.asp', async (req, res) => {
     const { rows: tables } = await execSql(pool, `SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'my' LIMIT 1`, [], { label: 'get_auth.asp_select' });
     if (tables.length === 0) {
       logger.error('[Google OAuth] my table does not exist');
-      return res.status(500).json({ error: 'User registry not available' });
+      return res.status(500).json([{ error: 'User registry not available' }]);
     }
 
     // ── Step 3: Look up existing user by Google ID (PHP: WHERE user.val=info.id AND user.t=USER) ──
@@ -4159,7 +4159,7 @@ router.get('/auth.asp', async (req, res) => {
     return res.redirect(redirectTo);
   } catch (err) {
     logger.error('[Google OAuth] Error', { error: err.message, stack: err.stack });
-    return res.status(500).json({ error: 'Google authentication failed', details: err.message });
+    return res.status(500).json([{ error: 'Google authentication failed', details: err.message }]);
   }
 });
 
@@ -4208,14 +4208,14 @@ router.get('/my/register', async (req, res) => {
     `, [userId], { label: 'get_my_register_select' });
 
     if (!rows.length || !rows[0].uid) {
-      return res.json({ error: 'EXPIRED' });
+      return res.json([{ error: 'EXPIRED' }]);
     }
 
     const row = rows[0];
 
     // Validate confirmation token
     if (row.token !== c) {
-      return res.json({ error: 'EXPIRED' });
+      return res.json([{ error: 'EXPIRED' }]);
     }
 
     // PHP line 97: Hash plaintext password — sha1(Salt(username, plaintext_pwd))
@@ -4240,7 +4240,7 @@ router.get('/my/register', async (req, res) => {
     return res.redirect('/my');
   } catch (err) {
     logger.error('[Legacy Register] Confirmation error', { error: err.message, userId });
-    return res.status(500).json({ error: 'Confirmation failed' });
+    return res.status(500).json([{ error: 'Confirmation failed' }]);
   }
 });
 
@@ -4259,7 +4259,7 @@ router.post('/my/register', async (req, res) => {
   if (!email || !/^.+@.+\..+$/.test(email)) {
     const msg = t9n('invalid_email', locale);
     if (isJSON) {
-      return res.json({ error: msg });
+      return res.json([{ error: msg }]);
     }
     return res.status(400).send(msg);
   }
@@ -4267,7 +4267,7 @@ router.post('/my/register', async (req, res) => {
   if (!regpwd || regpwd.length < 6) {
     const msg = t9n('password_too_short', locale);
     if (isJSON) {
-      return res.json({ error: msg });
+      return res.json([{ error: msg }]);
     }
     return res.status(400).send(msg);
   }
@@ -4275,14 +4275,14 @@ router.post('/my/register', async (req, res) => {
   if (regpwd !== regpwd1) {
     const msg = t9n('passwords_mismatch', locale);
     if (isJSON) {
-      return res.json({ error: msg });
+      return res.json([{ error: msg }]);
     }
     return res.status(400).send(msg);
   }
 
   if (!agree) {
     const msg = t9n('accept_terms', locale);
-    if (isJSON) return res.json({ error: msg });
+    if (isJSON) return res.json([{ error: msg }]);
     return res.status(400).send(msg);
   }
 
@@ -4299,7 +4299,7 @@ router.post('/my/register', async (req, res) => {
       const { rows: existing } = await execSql(pool, `SELECT id FROM my WHERE val = ? AND t = ${TYPE.USER} LIMIT 1`, [email.toLowerCase()], { label: 'post_my_register_select' });
       if (existing.length > 0) {
         const msg = t9n('email_registered', locale) + ' [errMailExists]';
-        if (isJSON) return res.json({ error: msg });
+        if (isJSON) return res.json([{ error: msg }]);
         return res.status(400).send(msg);
       }
 
@@ -4338,7 +4338,7 @@ router.post('/my/register', async (req, res) => {
     }
   } catch (err) {
     logger.error('[Legacy Register] DB error', { error: err.message, email });
-    if (isJSON) return res.json({ error: 'Registration failed: ' + err.message });
+    if (isJSON) return res.json([{ error: 'Registration failed: ' + err.message }]);
     return res.status(500).send('Registration failed');
   }
 
@@ -4520,7 +4520,7 @@ router.get('/:db', async (req, res, next) => {
   if (!token) {
     // JSON API request without token gets 401
     if (isApiRequest(req)) {
-      return res.status(401).json({ error: 'Unauthorized', hint: `POST /${db}/auth?JSON with login+pwd to get token` });
+      return res.status(401).json([{ error: 'Unauthorized', hint: `POST /${db}/auth?JSON with login+pwd to get token` }]);
     }
     // Serve login page
     const loginPage = path.join(legacyPath, 'index.html');
@@ -4541,7 +4541,7 @@ router.get('/:db', async (req, res, next) => {
     if (!await dbExists(db)) {
       res.clearCookie(db, { path: '/' });
       if (isApiRequest(req)) {
-        return res.status(404).json({ error: 'Database not found' });
+        return res.status(404).json([{ error: 'Database not found' }]);
       }
       return res.redirect(`/${db}`);
     }
@@ -4569,7 +4569,7 @@ router.get('/:db', async (req, res, next) => {
       // Invalid token - clear cookie and redirect to login
       res.clearCookie(db, { path: '/' });
       if (isApiRequest(req)) {
-        return res.status(401).json({ error: 'Invalid token' });
+        return res.status(401).json([{ error: 'Invalid token' }]);
       }
       return res.redirect(`/${db}`);
     }
@@ -4649,7 +4649,7 @@ router.get('/:db/:page*', async (req, res, next) => {
   // JSON API requests get a 401 instead of a redirect
   if (!token && page !== 'auth' && page !== 'login' && page !== 'register') {
     if (isApiRequest(req)) {
-      return res.status(401).json({ error: 'Unauthorized', hint: `POST /${db}/auth?JSON with login+pwd to get token` });
+      return res.status(401).json([{ error: 'Unauthorized', hint: `POST /${db}/auth?JSON with login+pwd to get token` }]);
     }
     return res.redirect(`/${db}?uri=${encodeURIComponent(req.originalUrl)}`);
   }
@@ -4665,7 +4665,7 @@ router.get('/:db/:page*', async (req, res, next) => {
 
     // JSON requested but page is a template page without required sub-id → JSON error
     if ((page === 'object' || page === 'edit_obj') && !subId) {
-      return res.status(200).json({ error: `typeId required: /${db}/${page}/{id}?JSON` });
+      return res.status(200).json([{ error: `typeId required: /${db}/${page}/{id}?JSON` }]);
     }
 
     // report + JSON: always pass to the dedicated report API route (list or detail)
@@ -5316,7 +5316,7 @@ router.get('/:db/:page*', async (req, res, next) => {
            LEFT JOIN \`${db}\` t ON t.id = o.t
            WHERE o.id = ?`, [subId], { label: 'query_select' });
         if (objResult.length === 0) {
-          return res.status(404).json({ error: 'Object not found' });
+          return res.status(404).json([{ error: 'Object not found' }]);
         }
         const obj         = objResult[0];
         const objTypName   = obj.type_name    || String(obj.t);
@@ -5877,7 +5877,7 @@ router.get('/:db/:page*', async (req, res, next) => {
     } catch (err) {
       logger.error('[Legacy page JSON] Error', { error: err.message, stack: err.stack, db, page });
       console.error('[DEBUG JSON Error]', err);
-      return res.status(200).json({ error: err.message });
+      return res.status(200).json([{ error: err.message }]);
     }
   }
 
@@ -6129,7 +6129,7 @@ router.post('/:db/_m_new/:up?', legacyAuthMiddleware, legacyXsrfCheck, (req, res
 
   const locale = getLocale(req, db);
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: t9n('invalid_database', locale) });
+    return res.status(200).json([{ error: t9n('invalid_database', locale) }]);
   }
 
   try {
@@ -6154,31 +6154,31 @@ router.post('/:db/_m_new/:up?', legacyAuthMiddleware, legacyXsrfCheck, (req, res
 
     // Reject invalid parentId and typeId
     if (parentId === 0) {
-      return res.status(200).json({ error: t9n('parent_id_zero', locale) });
+      return res.status(200).json([{ error: t9n('parent_id_zero', locale) }]);
     }
     if (!typeId || typeId === 0) {
-      return res.status(200).json({ error: t9n('type_required', locale) });
+      return res.status(200).json([{ error: t9n('type_required', locale) }]);
     }
 
     // Verify type and parent exist
     const { rows: typeCheck } = await execSql(pool, `SELECT id FROM \`${db}\` WHERE id = ? LIMIT 1`, [typeId], { label: 'post_db_m_new_up_select' });
     if (typeCheck.length === 0) {
-      return res.status(200).json({ error: `Type ${typeId} does not exist` });
+      return res.status(200).json([{ error: `Type ${typeId} does not exist` }]);
     }
     const { rows: parentCheck } = await execSql(pool, `SELECT id FROM \`${db}\` WHERE id = ? LIMIT 1`, [parentId], { label: 'post_db_m_new_up_select' });
     if (parentCheck.length === 0) {
-      return res.status(200).json({ error: `Parent ${parentId} does not exist` });
+      return res.status(200).json([{ error: `Parent ${parentId} does not exist` }]);
     }
 
     // Grant check + grant1Level when parentId === 1
     if (parentId === 1) {
       const level = await grant1Level(pool, db, grants || {}, typeId, username || '');
       if (!level || level === false) {
-        return res.status(200).json({ error: 'Insufficient privileges' });
+        return res.status(200).json([{ error: 'Insufficient privileges' }]);
       }
     } else {
       if (!await checkGrant(pool, db, grants || {}, parentId, typeId, 'WRITE', username || '')) {
-        return res.status(200).json({ error: 'Insufficient privileges' });
+        return res.status(200).json([{ error: 'Insufficient privileges' }]);
       }
     }
 
@@ -6193,7 +6193,7 @@ router.post('/:db/_m_new/:up?', legacyAuthMiddleware, legacyXsrfCheck, (req, res
     if (baseType === TYPE.REPORT_COLUMN && parseInt(value, 10) !== 0) {
       const repColResult = await checkRepColGranted(pool, db, grants || {}, parseInt(value, 10), 0, username || '');
       if (repColResult === 'NOT_GRANTED') {
-        return res.status(200).json({ error: `Object type #${value} is not granted` });
+        return res.status(200).json([{ error: `Object type #${value} is not granted` }]);
       }
     }
 
@@ -6356,7 +6356,7 @@ router.post('/:db/_m_new/:up?', legacyAuthMiddleware, legacyXsrfCheck, (req, res
               if (!defValSet[attrTypeId]) {
                 const valGrantResult = await checkValGranted(pool, db, grants || {}, attrTypeIdNum, refCheck[0].val, rv);
                 if (valGrantResult === 'BARRED') {
-                  return res.status(200).json({ error: `You do not have this object granted (${refCheck[0].val}) (${attrTypeIdNum})` });
+                  return res.status(200).json([{ error: `You do not have this object granted (${refCheck[0].val}) (${attrTypeIdNum})` }]);
                 }
               }
               const attrOrder = await getRefOrd(pool, db, id, attrTypeIdNum);
@@ -6419,7 +6419,7 @@ router.post('/:db/_m_new/:up?', legacyAuthMiddleware, legacyXsrfCheck, (req, res
     return res.redirect(`/${db}/${next_act}${idPart}${argPart}${hashPart}`);
   } catch (error) {
     logger.error({ error: error.message, db }, '[Legacy _m_new] Error');
-    return res.status(200).json({ error: error.message });
+    return res.status(200).json([{ error: error.message }]);
   }
 });
 
@@ -6583,7 +6583,7 @@ router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, (req, res
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -6597,15 +6597,15 @@ router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, (req, res
     // Existence check + metadata protection
     const { rows: existCheck } = await execSql(pool, `SELECT id, up FROM \`${db}\` WHERE id = ? LIMIT 1`, [originalId], { label: 'post_db_m_save_id_select' });
     if (existCheck.length === 0) {
-      return res.status(200).json({ error: 'Object not found' });
+      return res.status(200).json([{ error: 'Object not found' }]);
     }
     if (existCheck[0].up === 0) {
-      return res.status(200).json({ error: 'Cannot modify metadata object' });
+      return res.status(200).json([{ error: 'Cannot modify metadata object' }]);
     }
 
     // Grant check — PHP checks WRITE grant before saving
     if (!await checkGrant(pool, db, grants || {}, originalId, 0, 'WRITE', username || '')) {
-      return res.status(200).json({ error: 'Insufficient privileges' });
+      return res.status(200).json([{ error: 'Insufficient privileges' }]);
     }
 
     // Check if this is a copy operation (PHP: isset($_REQUEST["copybtn"]))
@@ -6631,7 +6631,7 @@ router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, (req, res
       `, [originalId], { label: 'post_db_m_save_id_select' });
 
       if (objRows.length === 0) {
-        return res.status(200).json({ error: 'Object not found' });
+        return res.status(200).json([{ error: 'Object not found' }]);
       }
 
       const original = objRows[0];
@@ -6704,7 +6704,7 @@ router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, (req, res
     if (req.body.val !== undefined) {
       // PHP line 8098: prevent renaming the admin user (val === db name)
       if (objTypeEarly === TYPE.USER && objValEarly === db && String(req.body.val) !== db) {
-        return res.status(200).json({ error: 'Please create another user instead of renaming the admin' });
+        return res.status(200).json([{ error: 'Please create another user instead of renaming the admin' }]);
       }
       await updateRowValue(db, objectId, req.body.val);
     }
@@ -6759,7 +6759,7 @@ router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, (req, res
         // PHP line 8098: prevent renaming the admin user
         // The admin user's val equals the database name ($z)
         if (objTypeEarly === TYPE.USER && objValEarly === db && String(attrValue) !== db) {
-          return res.status(200).json({ error: 'Please create another user instead of renaming the admin' });
+          return res.status(200).json([{ error: 'Please create another user instead of renaming the admin' }]);
         }
         await updateRowValue(db, objectId, String(attrValue));
         continue;
@@ -6857,14 +6857,14 @@ router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, (req, res
           if (refCheck.length > 0) {
             const valGrantResult = await checkValGranted(pool, db, grants || {}, typeIdNum, refCheck[0].val, refVal);
             if (valGrantResult === 'BARRED') {
-              return res.status(200).json({ error: `You do not have this object granted (${refCheck[0].val}) (${typeIdNum})` });
+              return res.status(200).json([{ error: `You do not have this object granted (${refCheck[0].val}) (${typeIdNum})` }]);
             }
           }
           // PHP parity: CheckRepColGranted for REPORT_COLUMN ref types (index.php:8095-8096)
           if (baseType === TYPE.REPORT_COLUMN) {
             const repColResult = await checkRepColGranted(pool, db, grants || {}, refVal, 0, username || '');
             if (repColResult === 'NOT_GRANTED') {
-              return res.status(200).json({ error: `Object type #${refVal} is not granted` });
+              return res.status(200).json([{ error: `Object type #${refVal} is not granted` }]);
             }
           }
         }
@@ -6962,7 +6962,7 @@ router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, (req, res
     legacyRespond(req, res, db, response);
   } catch (error) {
     logger.error('[Legacy _m_save] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -6974,7 +6974,7 @@ router.post('/:db/_m_del/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -6983,17 +6983,17 @@ router.post('/:db/_m_del/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req
     const { grants, username, uid } = req.legacyUser || {};
 
     if (!objectId) {
-      return res.status(200).json({ error: `Wrong id: ${id}` });
+      return res.status(200).json([{ error: `Wrong id: ${id}` }]);
     }
 
     // Grant check — PHP checks WRITE grant before deletion
     if (!await checkGrant(pool, db, grants || {}, objectId, 0, 'WRITE', username || '')) {
-      return res.status(200).json({ error: 'Insufficient privileges' });
+      return res.status(200).json([{ error: 'Insufficient privileges' }]);
     }
 
     // Self-deletion prevention: user cannot delete themselves
     if (objectId === uid) {
-      return res.status(200).json({ error: 'You cannot delete yourself' });
+      return res.status(200).json([{ error: 'You cannot delete yourself' }]);
     }
 
     // PHP: SELECT count(r.id), obj.up, obj.ord, obj.t, obj.val, par.up pup, type.up tup
@@ -7011,19 +7011,19 @@ router.post('/:db/_m_del/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req
        WHERE obj.id = ?`, [objectId], { label: 'post_db_m_del_id_select' });
 
     if (!row || row.pup == null) {
-      return res.status(200).json({ error: 'Object not found' });
+      return res.status(200).json([{ error: 'Object not found' }]);
     }
 
     // PHP: if pup==0 → can't delete metadata
     if (String(row.pup) === '0') {
-      return res.status(200).json({ error: `You can't delete metadata (type ${objectId})!` });
+      return res.status(200).json([{ error: `You can't delete metadata (type ${objectId})!` }]);
     }
 
     // PHP: if refCount > 0 → can't delete (has references)
     const cascade = req.body.cascade === '1' || req.body.cascade === true ||
                     req.query.forced !== undefined;
     if (!cascade && row.refCount > 0) {
-      return res.status(200).json({ error: `You can't delete an object that has links to it (total: ${row.refCount})!` });
+      return res.status(200).json([{ error: `You can't delete an object that has links to it (total: ${row.refCount})!` }]);
     }
 
     // PHP: adjust peer orders for array or multiselect elements
@@ -7055,7 +7055,7 @@ router.post('/:db/_m_del/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req
     });
   } catch (error) {
     logger.error('[Legacy _m_del] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -7069,7 +7069,7 @@ router.post('/:db/_m_set/:id', legacyAuthMiddleware, legacyXsrfCheck, upload.any
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -7079,7 +7079,7 @@ router.post('/:db/_m_set/:id', legacyAuthMiddleware, legacyXsrfCheck, upload.any
 
     // Grant check — PHP checks WRITE grant before setting attributes
     if (!await checkGrant(pool, db, grants || {}, objectId, 0, 'WRITE', username || '')) {
-      return res.status(200).json({ error: 'Insufficient privileges' });
+      return res.status(200).json([{ error: 'Insufficient privileges' }]);
     }
 
     // Merge query+body: smartq.js line 959 sends &t{ref}=value in URL query string for select2 inline edit
@@ -7098,7 +7098,7 @@ router.post('/:db/_m_set/:id', legacyAuthMiddleware, legacyXsrfCheck, upload.any
     }
 
     if (Object.keys(attributes).length === 0) {
-      return res.status(200).json({ error: 'No attributes provided'  });
+      return res.status(200).json([{ error: 'No attributes provided'  }]);
     }
 
     let uploadedFilePath = null;
@@ -7226,7 +7226,7 @@ router.post('/:db/_m_set/:id', legacyAuthMiddleware, legacyXsrfCheck, upload.any
     });
   } catch (error) {
     logger.error('[Legacy _m_set] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -7239,7 +7239,7 @@ router.post('/:db/_m_move/:id', legacyAuthMiddleware, legacyXsrfCheck, async (re
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -7251,16 +7251,16 @@ router.post('/:db/_m_move/:id', legacyAuthMiddleware, legacyXsrfCheck, async (re
 
     // Grant check on source object and target parent
     if (!await checkGrant(pool, db, grants || {}, objectId, 0, 'WRITE', username || '')) {
-      return res.status(200).json({ error: 'Insufficient privileges' });
+      return res.status(200).json([{ error: 'Insufficient privileges' }]);
     }
     if (!await checkGrant(pool, db, grants || {}, newParentId, 0, 'WRITE', username || '')) {
-      return res.status(200).json({ error: 'Insufficient privileges for target parent' });
+      return res.status(200).json([{ error: 'Insufficient privileges for target parent' }]);
     }
 
     // Fetch full object info (t, up, ord) before moving
     const { rows: objInfo } = await execSql(pool, `SELECT t, up, ord FROM \`${db}\` WHERE id = ? LIMIT 1`, [objectId], { label: 'post_db_m_move_id_select' });
     if (objInfo.length === 0) {
-      return res.status(200).json({ error: 'Object not found' });
+      return res.status(200).json([{ error: 'Object not found' }]);
     }
     const objType = objInfo[0].t;
     const oldParentId = objInfo[0].up;
@@ -7268,7 +7268,7 @@ router.post('/:db/_m_move/:id', legacyAuthMiddleware, legacyXsrfCheck, async (re
 
     // Metadata protection: can't move root-level types
     if (oldParentId === 0) {
-      return res.status(200).json({ error: 'Cannot move metadata object' });
+      return res.status(200).json([{ error: 'Cannot move metadata object' }]);
     }
 
     // Type mismatch guard: old parent and new parent must be of the same type
@@ -7276,10 +7276,10 @@ router.post('/:db/_m_move/:id', legacyAuthMiddleware, legacyXsrfCheck, async (re
        FROM \`${db}\` old_p, \`${db}\` new_p
        WHERE old_p.id = ? AND new_p.id = ?`, [oldParentId, newParentId], { label: 'post_db_m_move_id_select' });
     if (parentRows.length === 0) {
-      return res.status(200).json({ error: 'Parent not found' });
+      return res.status(200).json([{ error: 'Parent not found' }]);
     }
     if (parentRows[0].ut !== parentRows[0].tt) {
-      return res.status(200).json({ error: `Types mismatch ${objType}!=${parentRows[0].tt}` });
+      return res.status(200).json([{ error: `Types mismatch ${objType}!=${parentRows[0].tt}` }]);
     }
 
     // Same-parent no-op: skip if already under the target parent
@@ -7312,7 +7312,7 @@ router.post('/:db/_m_move/:id', legacyAuthMiddleware, legacyXsrfCheck, async (re
     });
   } catch (error) {
     logger.error('[Legacy _m_move] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -7328,7 +7328,7 @@ router.all('/:db/_dict/:typeId?', async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -7385,7 +7385,7 @@ router.all('/:db/_dict/:typeId?', async (req, res) => {
     res.json(types);
   } catch (error) {
     logger.error('[Legacy _dict] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -7398,7 +7398,7 @@ router.all('/:db/_list/:typeId', async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -7525,7 +7525,7 @@ router.all('/:db/_list/:typeId', async (req, res) => {
     });
   } catch (error) {
     logger.error('[Legacy _list] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -7541,7 +7541,7 @@ router.all('/:db/_list_join/:typeId', async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -7631,7 +7631,7 @@ router.all('/:db/_list_join/:typeId', async (req, res) => {
     });
   } catch (error) {
     logger.error('[Legacy _list_join] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -7643,7 +7643,7 @@ router.all('/:db/_d_main/:typeId', async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -7654,7 +7654,7 @@ router.all('/:db/_d_main/:typeId', async (req, res) => {
     const { rows: typeRows } = await execSql(pool, `SELECT id, val AS name, t AS base_type, ord FROM ${db} WHERE id = ?`, [type], { label: 'joinReqs_select' });
 
     if (typeRows.length === 0) {
-      return res.status(404).json({ error: 'Type not found' });
+      return res.status(404).json([{ error: 'Type not found' }]);
     }
 
     // Get requisites (children of the type)
@@ -7714,7 +7714,7 @@ router.all('/:db/_d_main/:typeId', async (req, res) => {
     res.json(result);
   } catch (error) {
     logger.error('[Legacy _d_main] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -7730,7 +7730,7 @@ router.get('/:db/terms', legacyAuthMiddleware, async (req, res) => {
   const { db } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -7815,7 +7815,7 @@ router.get('/:db/terms', legacyAuthMiddleware, async (req, res) => {
     res.json(types);
   } catch (error) {
     logger.error('[Legacy terms] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -7895,7 +7895,7 @@ router.get('/:db/_ref_reqs/:refId', legacyAuthMiddleware, async (req, res) => {
   const { db, refId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -7926,7 +7926,7 @@ router.get('/:db/_ref_reqs/:refId', legacyAuthMiddleware, async (req, res) => {
       // Fallback to simple query if the complex query returns nothing
       const { rows: simpleRows } = await execSql(pool, `SELECT t, val FROM ${db} WHERE id = ?`, [id], { label: 'get_db_ref_reqs_refId_select' });
       if (simpleRows.length === 0) {
-        return res.status(404).json({ error: 'Reference not found' });
+        return res.status(404).json([{ error: 'Reference not found' }]);
       }
 
       const refTypeId = simpleRows[0].t;
@@ -8245,7 +8245,7 @@ router.get('/:db/_ref_reqs/:refId', legacyAuthMiddleware, async (req, res) => {
     res.json(result);
   } catch (error) {
     logger.error('[Legacy _ref_reqs] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8257,7 +8257,7 @@ router.all('/:db/_connect/:id?', legacyAuthMiddleware, async (req, res) => {
   const { db, id: idParam } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   const objectId = parseInt(idParam || '0', 10);
@@ -8316,10 +8316,10 @@ router.all('/:db/_connect/:id?', legacyAuthMiddleware, async (req, res) => {
     if (await dbExists(db)) {
       res.json({ status: 'Ok', message: 'Connection successful' });
     } else {
-      res.status(404).json({ error: 'Database not found' });
+      res.status(404).json([{ error: 'Database not found' }]);
     }
   } catch (error) {
-    res.status(200).json({ error: 'Connection failed'  });
+    res.status(200).json([{ error: 'Connection failed'  }]);
   }
 });
 
@@ -8380,7 +8380,7 @@ router.post('/:db/_d_new/:parentTypeId?', legacyAuthMiddleware, legacyXsrfCheck,
   const { db, parentTypeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8389,12 +8389,12 @@ router.post('/:db/_d_new/:parentTypeId?', legacyAuthMiddleware, legacyXsrfCheck,
 
     // PHP line 8630-8631: if($val == "") my_die("Empty type")
     if (!name) {
-      return res.status(200).json({ error: 'Type name (val) is required'  });
+      return res.status(200).json([{ error: 'Type name (val) is required'  }]);
     }
 
     // PHP line 8632-8633: if(!isset($_REQUEST["t"])) my_die("Base type is not set")
     if (req.body.t === undefined && req.query.t === undefined) {
-      return res.status(200).json({ error: 'Base type is not set' });
+      return res.status(200).json([{ error: 'Base type is not set' }]);
     }
 
     const baseType = parseInt(req.body.t ?? req.query.t, 10);
@@ -8402,7 +8402,7 @@ router.post('/:db/_d_new/:parentTypeId?', legacyAuthMiddleware, legacyXsrfCheck,
     // PHP line 8634-8635: if(!isset($GLOBALS["basics"][$_REQUEST["t"]]) && ($_REQUEST["t"] !== "0"))
     //   my_die("Base type is invalid: ...")
     if (!REV_BASE_TYPE[baseType] && baseType !== 0) {
-      return res.status(200).json({ error: `Base type is invalid: ${baseType}` });
+      return res.status(200).json([{ error: `Base type is invalid: ${baseType}` }]);
     }
 
     // PHP line 8636-8641: duplicate (val, t) check at root level
@@ -8439,7 +8439,7 @@ router.post('/:db/_d_new/:parentTypeId?', legacyAuthMiddleware, legacyXsrfCheck,
     legacyRespond(req, res, db, { id: '', obj: id, next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_new] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8452,7 +8452,7 @@ router.post('/:db/_d_save/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legac
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8468,14 +8468,14 @@ router.post('/:db/_d_save/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legac
     const unique = (req.body.unique !== undefined || req.query.unique !== undefined) ? 1 : 0;
 
     if (val === undefined && t === undefined) {
-      return res.status(200).json({ error: 'No fields to update'  });
+      return res.status(200).json([{ error: 'No fields to update'  }]);
     }
 
     // PHP parity: duplicate name check — cannot rename type to an existing name
     if (val !== undefined) {
       const { rows: dupeRows } = await execSql(pool, `SELECT id FROM \`${db}\` WHERE up = 0 AND val = ? AND id != ? LIMIT 1`, [val, id], { label: 'unique_select' });
       if (dupeRows.length > 0) {
-        return res.status(200).json({ error: `Type with name "${val}" already exists` });
+        return res.status(200).json([{ error: `Type with name "${val}" already exists` }]);
       }
     }
 
@@ -8496,7 +8496,7 @@ router.post('/:db/_d_save/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legac
     legacyRespond(req, res, db, { id, obj: id, next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_save] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8508,7 +8508,7 @@ router.post('/:db/_d_del/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8554,7 +8554,7 @@ router.post('/:db/_d_del/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
     legacyRespond(req, res, db, { id, obj: null, next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_del] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8567,7 +8567,7 @@ router.post('/:db/_d_req/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8581,30 +8581,30 @@ router.post('/:db/_d_req/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
     const pool = getPool();
 
     if (!name) {
-      return res.status(200).json({ error: 'Requisite name (val) is required'  });
+      return res.status(200).json([{ error: 'Requisite name (val) is required'  }]);
     }
 
     // PHP parity (Add_Req): validate before adding requisite
     // 1. Target type exists
     const { rows: targetRows } = await execSql(pool, `SELECT id, up FROM \`${db}\` WHERE id = ? LIMIT 1`, [parentId], { label: 'post_db_d_req_typeId_select' });
     if (targetRows.length === 0) {
-      return res.status(200).json({ error: `Type ${parentId} does not exist` });
+      return res.status(200).json([{ error: `Type ${parentId} does not exist` }]);
     }
 
     // 2. Target is metadata row (up = 0) — cannot add requisite to instance
     if (targetRows[0].up !== 0) {
-      return res.status(200).json({ error: 'Cannot add requisite to an instance, only to type definitions' });
+      return res.status(200).json([{ error: 'Cannot add requisite to an instance, only to type definitions' }]);
     }
 
     // 3. Not self-referencing (type cannot reference itself)
     if (reqType === parentId) {
-      return res.status(200).json({ error: 'Type cannot reference itself' });
+      return res.status(200).json([{ error: 'Type cannot reference itself' }]);
     }
 
     // 4. Not duplicate — check if requisite of this type already exists
     const { rows: dupeRows } = await execSql(pool, `SELECT id FROM \`${db}\` WHERE up = ? AND t = ? LIMIT 1`, [parentId, reqType], { label: 'post_db_d_req_typeId_select' });
     if (dupeRows.length > 0) {
-      return res.status(200).json({ error: `Requisite of type ${reqType} already exists on type ${parentId}` });
+      return res.status(200).json([{ error: `Requisite of type ${reqType} already exists on type ${parentId}` }]);
     }
 
     // 5. MULTI_MASK auto-application (PHP parity: index.php ~8575)
@@ -8633,7 +8633,7 @@ router.post('/:db/_d_req/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
     legacyRespond(req, res, db, { id, obj: parentId, next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_req] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8646,7 +8646,7 @@ router.post('/:db/_d_alias/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8656,19 +8656,19 @@ router.post('/:db/_d_alias/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
 
     // PHP parity: reject colons in alias — reserved for internal markers like :MULTI:
     if (newAlias.includes(':')) {
-      return res.status(200).json({ error: 'Alias cannot contain colon character' });
+      return res.status(200).json([{ error: 'Alias cannot contain colon character' }]);
     }
 
     // Get current value
     const obj = await getObjectById(db, id);
     if (!obj) {
-      return res.status(404).json({ error: 'Requisite not found' });
+      return res.status(404).json([{ error: 'Requisite not found' }]);
     }
 
     // PHP parity (lines 8604-8607): hierarchy check — parent (obj.t) must be metadata root (up=0)
     const parent = await getObjectById(db, obj.t);
     if (!parent || parent.up !== 0) {
-      return res.status(200).json({ error: 'Error in subordination of the link object' });
+      return res.status(200).json([{ error: 'Error in subordination of the link object' }]);
     }
 
     // Parse existing modifiers
@@ -8686,7 +8686,7 @@ router.post('/:db/_d_alias/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
     legacyRespond(req, res, db, { id: String(obj.up), obj: String(obj.up), next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_alias] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8699,7 +8699,7 @@ router.post('/:db/_d_null/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacy
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8709,13 +8709,13 @@ router.post('/:db/_d_null/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacy
     // Get current value
     const obj = await getObjectById(db, id);
     if (!obj) {
-      return res.status(404).json({ error: 'Requisite not found' });
+      return res.status(404).json([{ error: 'Requisite not found' }]);
     }
 
     // Metadata verification: only allow toggling nullable on metadata-level requisites (parent.up === 0)
     const { rows: parentRows } = await execSql(pool, `SELECT up FROM \`${db}\` WHERE id = ? LIMIT 1`, [obj.up], { label: 'post_db_d_null_reqId_select' });
     if (parentRows.length === 0 || parentRows[0].up !== 0) {
-      return res.status(200).json({ error: 'Can only toggle NULL on type definitions, not instances' });
+      return res.status(200).json([{ error: 'Can only toggle NULL on type definitions, not instances' }]);
     }
 
     // Parse existing modifiers
@@ -8738,7 +8738,7 @@ router.post('/:db/_d_null/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacy
     legacyRespond(req, res, db, { id, obj: String(obj.up), next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_null] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8751,7 +8751,7 @@ router.post('/:db/_d_multi/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8761,13 +8761,13 @@ router.post('/:db/_d_multi/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
     // Get current value
     const obj = await getObjectById(db, id);
     if (!obj) {
-      return res.status(404).json({ error: 'Requisite not found' });
+      return res.status(404).json([{ error: 'Requisite not found' }]);
     }
 
     // Metadata verification: only allow toggling multi on metadata-level requisites (parent.up === 0)
     const { rows: parentRows } = await execSql(pool, `SELECT up FROM \`${db}\` WHERE id = ? LIMIT 1`, [obj.up], { label: 'post_db_d_multi_reqId_select' });
     if (parentRows.length === 0 || parentRows[0].up !== 0) {
-      return res.status(200).json({ error: 'Can only toggle MULTI on type definitions, not instances' });
+      return res.status(200).json([{ error: 'Can only toggle MULTI on type definitions, not instances' }]);
     }
 
     // Parse existing modifiers
@@ -8790,7 +8790,7 @@ router.post('/:db/_d_multi/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
     legacyRespond(req, res, db, { id, obj: String(obj.up), next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_multi] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8803,7 +8803,7 @@ router.post('/:db/_d_attrs/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8813,7 +8813,7 @@ router.post('/:db/_d_attrs/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
     // Get current value
     const obj = await getObjectById(db, id);
     if (!obj) {
-      return res.status(404).json({ error: 'Requisite not found' });
+      return res.status(404).json([{ error: 'Requisite not found' }]);
     }
 
     // Parse existing modifiers
@@ -8844,7 +8844,7 @@ router.post('/:db/_d_attrs/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legac
     legacyRespond(req, res, db, { id, obj: String(parentTypeId), next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_attrs] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8856,7 +8856,7 @@ router.post('/:db/_d_up/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDd
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8866,7 +8866,7 @@ router.post('/:db/_d_up/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDd
     // Get current object
     const obj = await getObjectById(db, id);
     if (!obj) {
-      return res.status(404).json({ error: 'Requisite not found' });
+      return res.status(404).json([{ error: 'Requisite not found' }]);
     }
 
     // Find the previous sibling (same parent, lower order)
@@ -8890,7 +8890,7 @@ router.post('/:db/_d_up/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyDd
     legacyRespond(req, res, db, { id: String(obj.up), obj: String(obj.up), next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_up] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8903,7 +8903,7 @@ router.post('/:db/_d_ord/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyD
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8912,7 +8912,7 @@ router.post('/:db/_d_ord/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyD
     const newOrd = parseInt(req.body.order || req.query.order, 10);
 
     if (isNaN(newOrd) || newOrd < 1) {
-      return res.status(200).json({ error: 'Invalid order'  });
+      return res.status(200).json([{ error: 'Invalid order'  }]);
     }
 
     const pool = getPool();
@@ -8921,7 +8921,7 @@ router.post('/:db/_d_ord/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyD
     const { rows: [reqRow] } = await execSql(pool, `SELECT req.ord, req.up FROM \`${db}\` req, \`${db}\` par WHERE req.id=? AND par.id=req.up AND par.up=0`, [id], { label: 'post_db_d_ord_reqId_select' });
 
     if (!reqRow) {
-      return res.status(200).json({ error: `Id=${id} not found`  });
+      return res.status(200).json([{ error: `Id=${id} not found`  }]);
     }
 
     const parentId = reqRow.up;
@@ -8945,7 +8945,7 @@ router.post('/:db/_d_ord/:reqId', legacyAuthMiddleware, legacyXsrfCheck, legacyD
     legacyRespond(req, res, db, { id: String(parentId), obj: String(parentId), next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_ord] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -8957,7 +8957,7 @@ router.post('/:db/_d_del_req/:reqId', legacyAuthMiddleware, legacyXsrfCheck, leg
   const { db, reqId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -8969,7 +8969,7 @@ router.post('/:db/_d_del_req/:reqId', legacyAuthMiddleware, legacyXsrfCheck, leg
     const { rows: [defRow] } = await execSql(pool, `SELECT def.up, def.t AS typ, def.ord, r.t AS parentT, r.val AS parentVal
        FROM \`${db}\` def, \`${db}\` r WHERE def.id = ? AND r.id = def.t`, [id], { label: 'post_db_d_del_req_reqId_select' });
     if (!defRow) {
-      return res.status(200).json({ error: 'Requisite not found' });
+      return res.status(200).json([{ error: 'Requisite not found' }]);
     }
     const typeId = defRow.up;
     const myord = defRow.ord;
@@ -9041,7 +9041,7 @@ router.post('/:db/_d_del_req/:reqId', legacyAuthMiddleware, legacyXsrfCheck, leg
     legacyRespond(req, res, db, { id: String(typeId), obj: String(typeId), next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_del_req] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -9057,14 +9057,14 @@ router.post('/:db/_d_ref/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
     const id = parseInt(typeId, 10);
 
     if (!id) {
-      return res.status(200).json({ error: `Invalid link (${id})`  });
+      return res.status(200).json([{ error: `Invalid link (${id})`  }]);
     }
 
     const pool = getPool();
@@ -9073,12 +9073,12 @@ router.post('/:db/_d_ref/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
     const { rows: [row] } = await execSql(pool, `SELECT obj.up, obj.t, ref.id refId FROM \`${db}\` obj LEFT JOIN \`${db}\` ref ON ref.up=0 AND ref.t=? AND ref.val='' WHERE obj.id=?`, [id, id], { label: 'post_db_d_ref_typeId_select' });
 
     if (!row) {
-      return res.status(200).json({ error: `${id} type not found`  });
+      return res.status(200).json([{ error: `${id} type not found`  }]);
     }
 
     // PHP: if(($row["up"] != 0) || ($row["t"] == $id)) die("Invalid $id type")
     if (row.up !== 0 || row.t === id) {
-      return res.status(200).json({ error: `Invalid ${id} type`  });
+      return res.status(200).json([{ error: `Invalid ${id} type`  }]);
     }
 
     let refId;
@@ -9096,7 +9096,7 @@ router.post('/:db/_d_ref/:typeId', legacyAuthMiddleware, legacyXsrfCheck, legacy
     legacyRespond(req, res, db, { id, obj: refId, next_act: 'edit_types', args: 'ext' });
   } catch (error) {
     logger.error('[Legacy _d_ref] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -9112,7 +9112,7 @@ router.post('/:db/_m_up/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req,
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -9122,13 +9122,13 @@ router.post('/:db/_m_up/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req,
 
     // Grant check — PHP checks WRITE grant before move-up
     if (!await checkGrant(pool, db, grants || {}, objectId, 0, 'WRITE', username || '')) {
-      return res.status(200).json({ error: 'Insufficient privileges' });
+      return res.status(200).json([{ error: 'Insufficient privileges' }]);
     }
 
     // Get current object
     const obj = await getObjectById(db, objectId);
     if (!obj) {
-      return res.status(404).json({ error: 'Object not found' });
+      return res.status(404).json([{ error: 'Object not found' }]);
     }
 
     // Find the previous sibling (same parent and type, lower order)
@@ -9152,7 +9152,7 @@ router.post('/:db/_m_up/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req,
     legacyRespond(req, res, db, { id: String(obj.t), obj: null, next_act: 'object', args: `F_U=${obj.up}` });
   } catch (error) {
     logger.error('[Legacy _m_up] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -9165,7 +9165,7 @@ router.post('/:db/_m_ord/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -9183,7 +9183,7 @@ router.post('/:db/_m_ord/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req
 
     // Grant check — PHP checks WRITE grant before reordering
     if (!await checkGrant(pool, db, grants || {}, objectId, 0, 'WRITE', username || '')) {
-      return res.status(200).json({ error: 'Insufficient privileges' });
+      return res.status(200).json([{ error: 'Insufficient privileges' }]);
     }
 
     // PHP: SELECT obj.ord, obj.up FROM $z obj, $z par
@@ -9194,7 +9194,7 @@ router.post('/:db/_m_ord/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req
        WHERE obj.id = ?`, [objectId], { label: 'post_db_m_ord_id_select' });
 
     if (!row) {
-      return res.status(200).json({ error: `Id=${objectId} not found` });
+      return res.status(200).json([{ error: `Id=${objectId} not found` }]);
     }
 
     const parentId = row.up;
@@ -9222,7 +9222,7 @@ router.post('/:db/_m_ord/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req
     legacyRespond(req, res, db, { id: String(parentId), obj: String(parentId), next_act: nextAct, args: '' });
   } catch (error) {
     logger.error('[Legacy _m_ord] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -9234,7 +9234,7 @@ router.post('/:db/_m_id/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req,
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database' });
+    return res.status(200).json([{ error: 'Invalid database' }]);
   }
 
   try {
@@ -9244,33 +9244,33 @@ router.post('/:db/_m_id/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req,
     const { grants, username } = req.legacyUser || {};
 
     if (!newId || newId <= 0) {
-      return res.status(200).json({ error: 'new_id must be a positive integer' });
+      return res.status(200).json([{ error: 'new_id must be a positive integer' }]);
     }
     if (oldId === newId) {
-      return res.status(200).json({ error: 'new_id must differ from current id' });
+      return res.status(200).json([{ error: 'new_id must differ from current id' }]);
     }
 
     // Grant check — PHP checks WRITE grant before ID change
     if (!await checkGrant(pool, db, grants || {}, oldId, 0, 'WRITE', username || '')) {
-      return res.status(200).json({ error: 'Insufficient privileges' });
+      return res.status(200).json([{ error: 'Insufficient privileges' }]);
     }
 
     // Check that the old object exists and get its parent
     const { rows: objRows } = await execSql(pool, `SELECT id, up FROM \`${db}\` WHERE id = ? LIMIT 1`, [oldId], { label: 'post_db_m_id_id_select' });
     if (objRows.length === 0) {
-      return res.status(200).json({ error: 'Object not found' });
+      return res.status(200).json([{ error: 'Object not found' }]);
     }
     const up = objRows[0].up;
 
     // Metadata guard: can't change ID of metadata (root-level types)
     if (objRows[0].up === 0) {
-      return res.status(200).json({ error: 'Cannot change ID of metadata object' });
+      return res.status(200).json([{ error: 'Cannot change ID of metadata object' }]);
     }
 
     // Check that new_id is not already in use
     const { rows: existRows } = await execSql(pool, `SELECT id FROM \`${db}\` WHERE id = ? LIMIT 1`, [newId], { label: 'post_db_m_id_id_select' });
     if (existRows.length > 0) {
-      return res.status(200).json({ error: `ID ${newId} is already in use` });
+      return res.status(200).json([{ error: `ID ${newId} is already in use` }]);
     }
 
     // PHP: 3 UPDATEs to rename the id everywhere it appears — wrap in transaction
@@ -9295,7 +9295,7 @@ router.post('/:db/_m_id/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req,
     legacyRespond(req, res, db, { id: newId, obj: newId, next_act: nextAct, args: '' });
   } catch (error) {
     logger.error('[Legacy _m_id] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message });
+    res.status(200).json([{ error: error.message }]);
   }
 });
 
@@ -9311,7 +9311,7 @@ router.all('/:db/obj_meta/:id', legacyAuthMiddleware, async (req, res) => {
   const { db, id } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -9347,7 +9347,7 @@ router.all('/:db/obj_meta/:id', legacyAuthMiddleware, async (req, res) => {
 
     if (rows.length === 0) {
       // PHP returns HTTP 200 with error JSON, not 404
-      return res.status(200).json({ error: 'not found' });
+      return res.status(200).json([{ error: 'not found' }]);
     }
 
     // Build response matching PHP format (line 8838-8857)
@@ -9388,7 +9388,7 @@ router.all('/:db/obj_meta/:id', legacyAuthMiddleware, async (req, res) => {
     res.json(meta);
   } catch (error) {
     logger.error('[Legacy obj_meta] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -9400,7 +9400,7 @@ router.all('/:db/metadata/:typeId?', legacyAuthMiddleware, async (req, res) => {
   const { db, typeId } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -9535,7 +9535,7 @@ router.all('/:db/metadata/:typeId?', legacyAuthMiddleware, async (req, res) => {
     }
   } catch (error) {
     logger.error('[Legacy metadata] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -9556,11 +9556,11 @@ router.post('/:db/jwt', async (req, res) => {
   const jwtToken = req.body.jwt || req.body.token || '';
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database' });
+    return res.status(200).json([{ error: 'Invalid database' }]);
   }
 
   if (!jwtToken) {
-    return res.status(200).json({ error: 'JWT verification failed' });
+    return res.status(200).json([{ error: 'JWT verification failed' }]);
   }
 
   try {
@@ -9574,24 +9574,24 @@ router.post('/:db/jwt', async (req, res) => {
       // PHP: openssl_verify("$header.$payload", $sig, $publicKey, OPENSSL_ALGO_SHA256)
       const parts = jwtToken.split('.');
       if (parts.length !== 3) {
-        return res.status(200).json({ error: 'JWT verification failed' });
+        return res.status(200).json([{ error: 'JWT verification failed' }]);
       }
       const [headerB64, payloadB64, sigB64] = parts;
       const sigBuf = Buffer.from(sigB64.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
       const data = Buffer.from(`${headerB64}.${payloadB64}`);
       const ok = crypto.verify('SHA256', data, { key: publicKey, padding: crypto.constants.RSA_PKCS1_PADDING }, sigBuf);
       if (!ok) {
-        return res.status(200).json({ error: 'JWT verification failed' });
+        return res.status(200).json([{ error: 'JWT verification failed' }]);
       }
       const payload = JSON.parse(Buffer.from(payloadB64.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString());
       const now = Math.floor(Date.now() / 1000);
       if (!payload.iat || !payload.exp || now > payload.exp || now < payload.iat) {
-        return res.status(200).json({ error: 'JWT expired' });
+        return res.status(200).json([{ error: 'JWT expired' }]);
       }
       // PHP: $params->data->userId
       username = payload?.data?.userId || payload?.sub || null;
       if (!username) {
-        return res.status(200).json({ error: 'JWT verification failed' });
+        return res.status(200).json([{ error: 'JWT verification failed' }]);
       }
     }
 
@@ -9609,7 +9609,7 @@ router.post('/:db/jwt', async (req, res) => {
        WHERE ${whereClause} LIMIT 1`, [whereParam], { label: 'post_db_jwt_select' });
 
     if (!rows.length) {
-      return res.status(200).json({ error: 'JWT verification failed' });
+      return res.status(200).json([{ error: 'JWT verification failed' }]);
     }
 
     const user = rows[0];
@@ -9631,7 +9631,7 @@ router.post('/:db/jwt', async (req, res) => {
     res.status(200).json({ _xsrf: newXsrf, token: newToken, id: String(user.uid), user: user.uname });
   } catch (error) {
     logger.error('[Legacy jwt] Error', { error: error.message, db });
-    res.status(200).json({ error: 'JWT verification failed' });
+    res.status(200).json([{ error: 'JWT verification failed' }]);
   }
 });
 
@@ -9654,7 +9654,7 @@ async function handleConfirm(req, res) {
   const p = req.query.p || req.body?.p || '';
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database' });
+    return res.status(200).json([{ error: 'Invalid database' }]);
   }
 
   try {
@@ -9705,13 +9705,13 @@ router.all('/my/_new_db', async (req, res) => {
   // Validate new database name (3-15 chars, starts with letter)
   const USER_DB_MASK = /^[a-z][a-z0-9]{2,14}$/i;
   if (!newDbName || !USER_DB_MASK.test(newDbName)) {
-    return res.status(200).json({ error: 'Invalid database name. Must be 3-15 characters, starting with a letter.' });
+    return res.status(200).json([{ error: 'Invalid database name. Must be 3-15 characters, starting with a letter.' }]);
   }
 
   // Check for reserved names
   const reservedNames = ['my', 'admin', 'root', 'system', 'test', 'demo', 'api', 'health'];
   if (reservedNames.includes(newDbName.toLowerCase())) {
-    return res.status(200).json({ error: `Database name "${newDbName}" is reserved` });
+    return res.status(200).json([{ error: `Database name "${newDbName}" is reserved` }]);
   }
 
   try {
@@ -9719,7 +9719,7 @@ router.all('/my/_new_db', async (req, res) => {
 
     // Check if database name is already registered (PHP: isDbVacant)
     if (!(await isDbVacant(pool, 'my', newDbName))) {
-      return res.status(200).json({ error: `Database "${newDbName}" already exists` });
+      return res.status(200).json([{ error: `Database "${newDbName}" already exists` }]);
     }
 
     // Create new database table with standard schema
@@ -9840,7 +9840,7 @@ router.all('/my/_new_db', async (req, res) => {
     });
   } catch (error) {
     logger.error('[Legacy _new_db] Error', { error: error.message, dbName: newDbName });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -9883,7 +9883,7 @@ function createDiskUpload(db) {
 router.post('/:db/upload', legacyAuthMiddleware, (req, res, next) => {
   const { db } = req.params;
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database' });
+    return res.status(200).json([{ error: 'Invalid database' }]);
   }
 
   // PHP parity: RepoGrant() must return WRITE for uploads
@@ -9891,14 +9891,14 @@ router.post('/:db/upload', legacyAuthMiddleware, (req, res, next) => {
   const grant = repoGrant(grants || {}, db, username || '');
   if (grant !== 'WRITE') {
     logger.warn('[Legacy upload] Repo grant denied', { db, username, grant });
-    return res.status(200).json({ error: 'Insufficient permissions to access this workplace' });
+    return res.status(200).json([{ error: 'Insufficient permissions to access this workplace' }]);
   }
 
   // Instantiate multer with disk storage for this specific db
   createDiskUpload(db).single('file')(req, res, (err) => {
     if (err) {
       logger.error('[Legacy upload] Multer error', { error: err.message, db });
-      return res.status(200).json({ error: err.message });
+      return res.status(200).json([{ error: err.message }]);
     }
     next();
   });
@@ -9906,7 +9906,7 @@ router.post('/:db/upload', legacyAuthMiddleware, (req, res, next) => {
   const { db } = req.params;
 
   if (!req.file) {
-    return res.status(200).json({ error: 'No file uploaded' });
+    return res.status(200).json([{ error: 'No file uploaded' }]);
   }
 
   // MIME-type verification using file magic bytes (PHP uses finfo_file)
@@ -9939,7 +9939,7 @@ router.post('/:db/upload', legacyAuthMiddleware, (req, res, next) => {
       if (!matches) {
         fs.unlinkSync(filePath); // Remove the invalid file
         logger.warn('[Legacy upload] MIME mismatch', { db, filename: req.file.originalname, fileExt });
-        return res.status(200).json({ error: `File content does not match extension ${fileExt}` });
+        return res.status(200).json([{ error: `File content does not match extension ${fileExt}` }]);
       }
     }
   } catch (mimeErr) {
@@ -9965,7 +9965,7 @@ router.get('/:db/download/:filename', legacyAuthMiddleware, async (req, res) => 
   const { db, filename } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   // PHP parity: RepoGrant() — any non-BARRED level (READ or WRITE) permits download
@@ -9973,7 +9973,7 @@ router.get('/:db/download/:filename', legacyAuthMiddleware, async (req, res) => 
   const grant = repoGrant(grants || {}, db, username || '');
   if (grant === 'BARRED') {
     logger.warn('[Legacy download] Repo grant denied', { db, username, grant });
-    return res.status(200).json({ error: 'Insufficient permissions to access this workplace' });
+    return res.status(200).json([{ error: 'Insufficient permissions to access this workplace' }]);
   }
 
   try {
@@ -9981,7 +9981,7 @@ router.get('/:db/download/:filename', legacyAuthMiddleware, async (req, res) => 
     const filePath = safePath(baseDir, filename);
 
     if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
-      return res.status(404).json({ error: 'File not found' });
+      return res.status(404).json([{ error: 'File not found' }]);
     }
 
     logger.info('[Legacy download] File download', { db, filename });
@@ -9989,10 +9989,10 @@ router.get('/:db/download/:filename', legacyAuthMiddleware, async (req, res) => 
     res.download(filePath, path.basename(filePath));
   } catch (error) {
     if (error.message === 'Invalid path') {
-      return res.status(200).json({ error: 'Invalid filename'  });
+      return res.status(200).json([{ error: 'Invalid filename'  }]);
     }
     logger.error('[Legacy download] Error', { error: error.message, db });
-    res.status(200).json({ error: 'Download failed'  });
+    res.status(200).json([{ error: 'Download failed'  }]);
   }
 });
 
@@ -10005,7 +10005,7 @@ router.get('/:db/dir_admin', legacyAuthMiddleware, async (req, res) => {
   const { download, add_path, gf } = req.query;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   // PHP parity: RepoGrant() check before dir_admin (index.php:6610-6612)
@@ -10013,7 +10013,7 @@ router.get('/:db/dir_admin', legacyAuthMiddleware, async (req, res) => {
   const grant = repoGrant(grants || {}, db, username || '');
   if (grant === 'BARRED') {
     logger.warn('[Legacy dir_admin] Repo grant denied', { db, username, grant });
-    return res.status(200).json({ error: 'Insufficient permissions to access this workplace' });
+    return res.status(200).json([{ error: 'Insufficient permissions to access this workplace' }]);
   }
 
   try {
@@ -10029,7 +10029,7 @@ router.get('/:db/dir_admin', legacyAuthMiddleware, async (req, res) => {
     try {
       fullPath = safePath(basePath, add_path || '');
     } catch {
-      return res.status(200).json({ error: 'Invalid path'  });
+      return res.status(200).json([{ error: 'Invalid path'  }]);
     }
 
     // Handle file download request
@@ -10038,12 +10038,12 @@ router.get('/:db/dir_admin', legacyAuthMiddleware, async (req, res) => {
       try {
         filePath = safePath(fullPath, gf);
       } catch {
-        return res.status(200).json({ error: 'Invalid filename'  });
+        return res.status(200).json([{ error: 'Invalid filename'  }]);
       }
       if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
         return res.download(filePath, path.basename(filePath));
       }
-      return res.status(404).json({ error: 'File not found' });
+      return res.status(404).json([{ error: 'File not found' }]);
     }
 
     // Create directory if it doesn't exist
@@ -10085,7 +10085,7 @@ router.get('/:db/dir_admin', legacyAuthMiddleware, async (req, res) => {
     });
   } catch (error) {
     logger.error('[Legacy dir_admin] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -10963,7 +10963,7 @@ router.all('/:db/report/:reportId?', async (req, res) => {
   const { execute, format } = req.query;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -10988,7 +10988,7 @@ router.all('/:db/report/:reportId?', async (req, res) => {
     const report = await compileReport(pool, db, id);
 
     if (!report) {
-      return res.status(404).json({ error: 'Report not found' });
+      return res.status(404).json([{ error: 'Report not found' }]);
     }
 
     // PHP parity: load grants and add granted flag per column
@@ -11339,7 +11339,7 @@ router.all('/:db/report/:reportId?', async (req, res) => {
     });
   } catch (error) {
     logger.error('[Legacy report] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -11352,7 +11352,7 @@ router.get('/:db/export/:typeId', async (req, res) => {
   const { format = 'csv', include_reqs = '1' } = req.query;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -11441,7 +11441,7 @@ router.get('/:db/export/:typeId', async (req, res) => {
     res.send(csv);
   } catch (error) {
     logger.error('[Legacy export] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -11457,7 +11457,7 @@ router.get('/:db/grants', async (req, res) => {
   const { db } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   try {
@@ -11467,7 +11467,7 @@ router.get('/:db/grants', async (req, res) => {
     const token = req.cookies[db] || req.headers.authorization?.replace(/^Bearer\s+/i, '');
 
     if (!token) {
-      return res.status(401).json({ error: 'No token provided' });
+      return res.status(401).json([{ error: 'No token provided' }]);
     }
 
     // Validate token and get user role
@@ -11481,7 +11481,7 @@ router.get('/:db/grants', async (req, res) => {
     `, [token], { label: 'get_db_grants_select' });
 
     if (userRows.length === 0) {
-      return res.status(401).json({ error: 'Invalid token' });
+      return res.status(401).json([{ error: 'Invalid token' }]);
     }
 
     const user = userRows[0];
@@ -11506,7 +11506,7 @@ router.get('/:db/grants', async (req, res) => {
     });
   } catch (error) {
     logger.error('[Legacy grants] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -11519,11 +11519,11 @@ router.post('/:db/check_grant', async (req, res) => {
   const { id, t, grant = 'READ' } = req.body;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   if (!id) {
-    return res.status(200).json({ error: 'Object ID required'  });
+    return res.status(200).json([{ error: 'Object ID required'  }]);
   }
 
   try {
@@ -11533,7 +11533,7 @@ router.post('/:db/check_grant', async (req, res) => {
     const token = req.cookies[db] || req.headers.authorization?.replace(/^Bearer\s+/i, '');
 
     if (!token) {
-      return res.status(401).json({ error: 'No token provided' });
+      return res.status(401).json([{ error: 'No token provided' }]);
     }
 
     // Validate token and get user
@@ -11547,7 +11547,7 @@ router.post('/:db/check_grant', async (req, res) => {
     `, [token], { label: 'post_db_check_grant_select' });
 
     if (userRows.length === 0) {
-      return res.status(401).json({ error: 'Invalid token' });
+      return res.status(401).json([{ error: 'Invalid token' }]);
     }
 
     const user = userRows[0];
@@ -11571,7 +11571,7 @@ router.post('/:db/check_grant', async (req, res) => {
     });
   } catch (error) {
     logger.error('[Legacy check_grant] Error', { error: error.message, db });
-    res.status(200).json({ error: error.message  });
+    res.status(200).json([{ error: error.message  }]);
   }
 });
 
@@ -12573,7 +12573,7 @@ router.post('/:db/bki-import', (req, res, next) => {
 }, async (req, res) => {
   const { db } = req.params;
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database' });
+    return res.status(200).json([{ error: 'Invalid database' }]);
   }
 
   try {
@@ -12604,7 +12604,7 @@ router.post('/:db/bki-import', (req, res, next) => {
     }
 
     if (!grants.EXPORT?.[1] && username.toLowerCase() !== 'admin' && username !== db) {
-      return res.status(403).json({ error: 'You do not have permission to import to the database' });
+      return res.status(403).json([{ error: 'You do not have permission to import to the database' }]);
     }
 
     // ── Get BKI content ──
@@ -12612,7 +12612,7 @@ router.post('/:db/bki-import', (req, res, next) => {
     if (req.file) {
       const entries = readZip(req.file.buffer);
       const bkiEntry = entries.find(e => e.name.endsWith('.bki')) || entries.find(e => e.name.endsWith('.dmp')) || entries[0];
-      if (!bkiEntry) return res.status(400).json({ error: 'No .bki file found in ZIP' });
+      if (!bkiEntry) return res.status(400).json([{ error: 'No .bki file found in ZIP' }]);
       bkiContent = bkiEntry.content.toString('utf8');
     } else if (typeof req.body === 'string') {
       bkiContent = req.body;
@@ -12623,7 +12623,7 @@ router.post('/:db/bki-import', (req, res, next) => {
     }
 
     if (!bkiContent) {
-      return res.status(400).json({ error: 'No BKI content provided' });
+      return res.status(400).json([{ error: 'No BKI content provided' }]);
     }
 
     // Remove BOM if present
@@ -12660,7 +12660,7 @@ router.post('/:db/bki-import', (req, res, next) => {
       // Plain data — structure already exists in DB, just import data rows
       const id = Number(req.body?.id || req.query?.id);
       if (!id || id <= 1) {
-        return res.status(400).json({ error: 'Plain DATA import requires ?id=<typeId> parameter' });
+        return res.status(400).json([{ error: 'Plain DATA import requires ?id=<typeId> parameter' }]);
       }
       rootTypeId = id;
       await constructHeader(pool, db, rootTypeId, ctx);
@@ -12671,7 +12671,7 @@ router.post('/:db/bki-import', (req, res, next) => {
       const rootTypParts = firstLine.split(':');
       rootTypeId = Number(rootTypParts[0]);
       if (!rootTypeId || rootTypeId <= 1) {
-        return res.status(400).json({ error: `Invalid metadata type ${rootTypParts[0]}` });
+        return res.status(400).json([{ error: `Invalid metadata type ${rootTypParts[0]}` }]);
       }
 
       // Build local structure for root type
@@ -13077,7 +13077,7 @@ router.post('/:db/bki-import', (req, res, next) => {
     });
   } catch (error) {
     logger.error('[Legacy BKI import] Error', { error: error.message, db });
-    res.status(500).json({ error: 'BKI import failed: ' + error.message });
+    res.status(500).json([{ error: 'BKI import failed: ' + error.message }]);
   }
 });
 
@@ -13103,7 +13103,7 @@ router.post('/:db/restore', (req, res, next) => {
   const { db } = req.params;
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database' });
+    return res.status(200).json([{ error: 'Invalid database' }]);
   }
 
   try {
@@ -13134,7 +13134,7 @@ router.post('/:db/restore', (req, res, next) => {
 
     // Check EXPORT grant (same as backup for restore)
     if (!grants.EXPORT?.[1] && username.toLowerCase() !== 'admin' && username !== db) {
-      return res.status(403).json({ error: 'You do not have permission to import to the database' });
+      return res.status(403).json([{ error: 'You do not have permission to import to the database' }]);
     }
 
     // Get dump content: file upload (ZIP) > backup_file param > body.content > body.data
@@ -13143,7 +13143,7 @@ router.post('/:db/restore', (req, res, next) => {
       // Extract .dmp text from uploaded ZIP
       const entries = readZip(req.file.buffer);
       const dmpEntry = entries.find(e => e.name.endsWith('.dmp')) || entries[0];
-      if (!dmpEntry) return res.status(400).json({ error: 'No .dmp file found in ZIP' });
+      if (!dmpEntry) return res.status(400).json([{ error: 'No .dmp file found in ZIP' }]);
       dumpContent = dmpEntry.content.toString('utf8');
     } else if (req.body?.backup_file || req.query?.backup_file) {
       // PHP: ?backup_file=path reads a ZIP from the filesystem
@@ -13152,16 +13152,16 @@ router.post('/:db/restore', (req, res, next) => {
       const backupDir = path.join(legacyPath, 'download', db);
       const backupFilePath = path.join(backupDir, backupFileName);
       if (!backupFilePath.startsWith(backupDir + path.sep) && backupFilePath !== backupDir) {
-        return res.status(400).json({ error: 'Invalid backup_file path' });
+        return res.status(400).json([{ error: 'Invalid backup_file path' }]);
       }
       if (!fs.existsSync(backupFilePath)) {
-        return res.status(400).json({ error: 'Backup file not found' });
+        return res.status(400).json([{ error: 'Backup file not found' }]);
       }
       const fileBuffer = fs.readFileSync(backupFilePath);
       if (backupFileName.endsWith('.zip')) {
         const entries = readZip(fileBuffer);
         const dmpEntry = entries.find(e => e.name.endsWith('.dmp')) || entries[0];
-        if (!dmpEntry) return res.status(400).json({ error: 'No .dmp file found in ZIP' });
+        if (!dmpEntry) return res.status(400).json([{ error: 'No .dmp file found in ZIP' }]);
         dumpContent = dmpEntry.content.toString('utf8');
       } else {
         dumpContent = fileBuffer.toString('utf8');
@@ -13175,7 +13175,7 @@ router.post('/:db/restore', (req, res, next) => {
     }
 
     if (!dumpContent) {
-      return res.status(400).json({ error: 'No backup content provided' });
+      return res.status(400).json([{ error: 'No backup content provided' }]);
     }
 
     // Parse the dump format (PHP lines 4196–4237)
@@ -13226,7 +13226,7 @@ router.post('/:db/restore', (req, res, next) => {
     }
 
     if (rows.length === 0) {
-      return res.status(400).json({ error: 'Empty or unrecognised dump file' });
+      return res.status(400).json([{ error: 'Empty or unrecognised dump file' }]);
     }
 
     // PHP parity: ?sql returns SQL statements as plain text instead of executing
@@ -13254,7 +13254,7 @@ router.post('/:db/restore', (req, res, next) => {
     res.json({ status: 'Ok', rows: rows.length });
   } catch (error) {
     logger.error('[Legacy restore] Error', { error: error.message, db });
-    res.status(500).json({ error: 'Restore failed: ' + error.message });
+    res.status(500).json([{ error: 'Restore failed: ' + error.message }]);
   }
 });
 
@@ -13379,12 +13379,12 @@ router.post('/:db', async (req, res, next) => {
   }
 
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database' });
+    return res.status(200).json([{ error: 'Invalid database' }]);
   }
 
   const reportId = parseInt(req.body.id || req.query.id, 10);
   if (!reportId) {
-    return res.status(200).json({ error: 'Report ID required' });
+    return res.status(200).json([{ error: 'Report ID required' }]);
   }
 
   try {
@@ -13393,7 +13393,7 @@ router.post('/:db', async (req, res, next) => {
     // Compile and execute the report
     const report = await compileReport(pool, db, reportId);
     if (!report) {
-      return res.status(404).json({ error: 'Report not found' });
+      return res.status(404).json([{ error: 'Report not found' }]);
     }
 
     // Parse filters from request
@@ -13546,7 +13546,7 @@ router.post('/:db', async (req, res, next) => {
     });
   } catch (error) {
     logger.error('[Legacy action=report] Error', { error: error.message, db, reportId });
-    return res.status(200).json({ error: error.message });
+    return res.status(200).json([{ error: error.message }]);
   }
 });
 
@@ -13559,7 +13559,7 @@ router.post('/:db/:action', async (req, res) => {
 
   // Validate DB name
   if (!isValidDbName(db)) {
-    return res.status(200).json({ error: 'Invalid database'  });
+    return res.status(200).json([{ error: 'Invalid database'  }]);
   }
 
   logger.warn('[Legacy API] Unknown action', { db, action, body: req.body });


### PR DESCRIPTION
## Summary
- PHP `my_die()` returns `[{"error":"msg"}]` (array), Node.js returned `{"error":"msg"}` (object)
- Legacy HTML templates use `json[0].error` — broke with object format
- Wrapped all 241 error responses in array brackets across routes and middleware

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)