### PR TITLE
fix: return xsrf id as string to match PHP response format (#354)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -7867,8 +7867,8 @@ router.get('/:db/xsrf', async (req, res) => {
       user: user.uname,
       // PHP: strtolower($row["role"]) where role = role_def.val
       role: (user.role_val || '').toLowerCase(),
-      // PHP: "id":123 (integer, no quotes)
-      id: Number(user.uid),
+      // PHP: "id":"123" (string from mysqli_fetch_array)
+      id: String(user.uid),
       msg: '',
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Changed `id: Number(user.uid)` to `id: String(user.uid)` in xsrf response
- PHP returns id as string

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)