### PR TITLE
fix: add Cache-Control/Expires headers to legacy-compat router (#377)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -249,6 +249,17 @@ async function makeTree(db, templateFile, rootBlock = '', params = {}) {
 
 const router = express.Router();
 
+// ── Cache-Control headers (Issue #377, PHP parity: index.php:2–4) ───────────
+// PHP sets these globally at the top of index.php before any routing:
+//   header("Cache-Control: no-store, no-cache, must-revalidate");
+//   header("Expires: ".date("r"));
+// Without these, browsers/proxies may cache JSON API responses and serve stale data.
+router.use((req, res, next) => {
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+  res.setHeader('Expires', new Date().toUTCString());
+  next();
+});
+
 // Apply PHP JSON key sorting middleware to achieve byte-for-byte parity (Issue #173)
 // PHP's json_encode() sorts keys alphabetically, while Node.js preserves insertion order.
 // This middleware ensures all JSON responses have keys sorted alphabetically.


### PR DESCRIPTION
## Summary

- Add router-level middleware to `legacy-compat.js` that sets `Cache-Control: no-store, no-cache, must-revalidate` and `Expires: <current UTC date>` on every response
- Matches PHP behavior from `index.php` lines 2–4, which sets these headers globally before any routing logic
- Prevents browsers, proxies, and CDNs from caching JSON API responses and serving stale data

Fixes #377

## Test plan

- [ ] Verify `Cache-Control: no-store, no-cache, must-revalidate` header is present on all legacy API responses
- [ ] Verify `Expires` header is present and set to the current date/time
- [ ] Confirm no regression in existing API behavior (headers are additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)