### PR TITLE
fix: relax X-Frame-Options for legacy routes (#390)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -264,6 +264,17 @@ router.use((req, res, next) => {
   next();
 });
 
+// Issue #390: Relax Helmet security headers for legacy routes to match PHP behavior.
+// PHP set no security headers at all, so clients may embed the application in iframes.
+// Helmet sets X-Frame-Options: DENY globally, which breaks iframe embedding.
+// For legacy routes we downgrade to SAMEORIGIN (allows same-origin iframes)
+// and remove Cross-Origin-Embedder-Policy which also blocks framing.
+router.use((req, res, next) => {
+  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+  res.removeHeader('Cross-Origin-Embedder-Policy');
+  next();
+});
+
 // Get the directory path for serving static files
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/backend/monolith/src/middleware/security/securityHeaders.js
+++ b/backend/monolith/src/middleware/security/securityHeaders.js
@@ -103,6 +103,7 @@ export const securityHeaders = helmet({
   },
 
   // X-Frame-Options (clickjacking protection)
+  // Note: legacy-compat routes override this to SAMEORIGIN (Issue #390)
   frameguard: {
     action: 'deny', // Prevent embedding in iframes
   },


### PR DESCRIPTION
## Summary

- Override Helmet's `X-Frame-Options: DENY` to `SAMEORIGIN` on legacy-compat routes, restoring PHP-compatible iframe embedding
- Remove `Cross-Origin-Embedder-Policy` header on legacy routes (also blocks framing)
- Add cross-reference comment in `securityHeaders.js` noting the override

## Root cause

Helmet applies `X-Frame-Options: DENY` globally (Issue #77). PHP set no security headers at all, so clients that embed Integram in same-origin iframes broke after the Node.js migration.

## Test plan

- [ ] Verify legacy routes return `X-Frame-Options: SAMEORIGIN` instead of `DENY`
- [ ] Verify non-legacy routes (API v2, static assets) still return `X-Frame-Options: DENY`
- [ ] Verify legacy pages can be embedded in same-origin iframes

Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)