### PR TITLE
fix: include username/db in auth error message (#384)

### DIFF
--- a/backend/monolith/src/services/aero/AeroDmonitorService.js
+++ b/backend/monolith/src/services/aero/AeroDmonitorService.js
@@ -76,7 +76,7 @@ export class AeroDmonitorService {
       })
 
       if (response.data && response.data.failed) {
-        throw new Error('Invalid login or password')
+        throw new Error(`Wrong credentials for user ${username} in ${this.database}. Please send login and password as POST-parameters.`)
       }
 
       this.session = {

--- a/backend/monolith/src/services/mcp/IntegramMCPClient.js
+++ b/backend/monolith/src/services/mcp/IntegramMCPClient.js
@@ -127,7 +127,7 @@ class IntegramMCPClient {
 
       // Check for authentication failure
       if (data.failed) {
-        throw new Error('Invalid login or password');
+        throw new Error(`Wrong credentials for user ${login} in ${this.database}. Please send login and password as POST-parameters.`);
       }
 
       // Get token from auth response

--- a/backend/monolith/src/services/mcp/integram-server.js
+++ b/backend/monolith/src/services/mcp/integram-server.js
@@ -321,7 +321,7 @@ class IntegramMCPClient {
     });
 
     if (response.data.failed) {
-      throw new Error('Invalid login or password');
+      throw new Error(`Wrong credentials for user ${login} in ${database}. Please send login and password as POST-parameters.`);
     }
 
     this.token = response.data.token;

--- a/backend/monolith/src/utils/IntegramClient.js
+++ b/backend/monolith/src/utils/IntegramClient.js
@@ -112,7 +112,7 @@ export class IntegramClient {
           success: false,
           details: { reason: 'Invalid credentials' }
         });
-        throw new Error('Invalid login or password');
+        throw new Error(`Wrong credentials for user ${username} in ${this.database}. Please send login and password as POST-parameters.`);
       }
 
       // Use response data directly instead of making a second request


### PR DESCRIPTION
## Summary
- Replaced generic `Invalid login or password` with PHP-parity format in 4 API client modules
- Error now reads: `Wrong credentials for user {login} in {db}. Please send login and password as POST-parameters.`
- Files changed: `IntegramClient.js`, `IntegramMCPClient.js`, `integram-server.js`, `AeroDmonitorService.js`

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)