### PR TITLE
fix: correct OAuth/JWT cookie expiry from 30 to 360 days (#381)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -3195,7 +3195,8 @@ router.all('/:db/auth', async (req, res, next) => {
     }
 
     // Set session cookie; remove secret cookie
-    res.cookie(db, tokenVal, { maxAge: 30 * 24 * 60 * 60 * 1000, path: '/', httpOnly: false });
+    // PHP: setcookie($z, $tok, 0, "/") — session cookie (expires on browser close)
+    res.cookie(db, tokenVal, { path: '/', httpOnly: false });
     res.clearCookie('secret', { path: '/' });
 
     logger.info('[Legacy SecretAuth] Success', { db, uid: user.uid, username: user.username });
@@ -9751,7 +9752,8 @@ router.post('/:db/jwt', async (req, res) => {
       act: null,
     });
 
-    res.cookie(db, newToken, { path: '/', httpOnly: false });
+    // PHP: setcookie($z, $token, time() + 2592000*12, "/") — 360 days
+    res.cookie(db, newToken, { maxAge: 360 * 24 * 60 * 60 * 1000, path: '/', httpOnly: false });
 
     logger.info('[Legacy jwt] JWT validated', { db, uid: user.uid });
 


### PR DESCRIPTION
## Summary

- **Secret auth**: removed `maxAge` so the cookie becomes a session cookie (expires on browser close), matching PHP's `setcookie($z, $tok, 0, "/")` at index.php:1120-1125
- **JWT auth**: added `maxAge: 360 * 24 * 60 * 60 * 1000` (360 days) to match PHP's `updateTokens()` which calls `setcookie($z, $token, time() + 2592000*12, "/")` at index.php:374
- Google OAuth and regular login already had correct expiry values

| Auth method | PHP | Node.js (before) | Node.js (after) |
|-------------|-----|-------------------|-----------------|
| Regular login | 30 days | 30 days | 30 days |
| Google OAuth | 360 days | 360 days | 360 days |
| JWT auth | 360 days | session | 360 days |
| Secret auth | session | 30 days | session |

Fixes #381

## Test plan

- [ ] Login with regular credentials — cookie should expire in 30 days
- [ ] Login via Google OAuth — cookie should expire in 360 days
- [ ] Authenticate via JWT endpoint — cookie should expire in 360 days
- [ ] Authenticate via secret token — cookie should be a session cookie (no `Expires`/`Max-Age` in `Set-Cookie` header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)