### PR TITLE
fix: correct report JSON field names and add header/footer (#387)

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/php-compat-gaps.test.js
+++ b/backend/monolith/src/api/routes/__tests__/php-compat-gaps.test.js
@@ -140,14 +140,23 @@ describe('P0 — Critical gaps', () => {
      */
 
     it('POST /:db with action=report&id=<n>&JSON should execute report and return data (IMPLEMENTED)', () => {
-      // legacy-compat.js lines 4977-4985: Default JSON format returns {columns, data, rownum}
+      // PHP parity: default JSON returns {columns, rows, totalCount, header, footer}
+      // rows = object keyed by row index, each row keyed by column ID
+      // granted = integer 1 (not boolean), type = integer type ID
       const mockResponse = {
-        columns: [{ id: 1, name: 'Col1', type: 8, format: 'CHARS' }],
-        data: [{ col1: 'value' }],
-        rownum: 1
+        columns: [{ id: 1, name: 'Col1', type: 8, format: 'CHARS', granted: 1 }],
+        rows: { '0': { '1': 'value' } },
+        totalCount: 1,
+        header: 'Report Title',
+        footer: []
       };
       expect(mockResponse).toHaveProperty('columns');
-      expect(mockResponse).toHaveProperty('data');
+      expect(mockResponse).toHaveProperty('rows');
+      expect(mockResponse).toHaveProperty('totalCount');
+      expect(mockResponse).toHaveProperty('header');
+      expect(mockResponse).toHaveProperty('footer');
+      expect(mockResponse.columns[0].granted).toBe(1);
+      expect(typeof mockResponse.columns[0].type).toBe('number');
     });
 
     it('POST /:db with action=report&id=<n>&JSON_KV should return [{col:val,...},...] (IMPLEMENTED)', () => {

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -11373,10 +11373,8 @@ router.all('/:db/report/:reportId?', async (req, res) => {
       }
 
       if (isApiRequest(req)) {
-        // PHP default JSON: column-major data[col_index][row_index]
-        // smartq.js getRep: iterates `for(i in json.data[0])` (rows of first col)
-        // smartq.js drawLine: uses `json.data[j][i]` (col j, row i)
-        // smartq.js drawFoot: checks 'totals' in json.columns[0] → embed totals in each column
+        // PHP default JSON (index.php:3828-3868): row-major rows object, integer type IDs,
+        // granted as integer 1, ref as integer 1, header/footer fields.
         const totalsMap = results.totals || {};
         // Build column entries; for object/ref columns emit a hidden {name}ID companion column
         // so smartq.js can set obj-id / ref-id attributes via zis.columns[col.name+'ID'].col
@@ -11384,17 +11382,17 @@ router.all('/:db/report/:reportId?', async (req, res) => {
         for (const col of report.columns) {
           colEntries.push({
             def: {
-              id: String(col.id),
+              id: col.id,
               name: col.name,
-              // type = requisite type ID as string (PHP mysqli returns strings for DB integers)
-              type: String(col.reqTypeId || 0),
+              // PHP parity: type = integer requisite type ID (PHP: $origType)
+              type: col.reqTypeId || 0,
               format: REV_BASE_TYPE[col.baseType] || 'CHARS',
               align: col.align || 'LEFT',
               totals: totalsMap[col.alias] !== undefined ? totalsMap[col.alias] : null,
-              // ref = truthy for reference columns; smartq uses ref-id vs obj-id
-              ref: col.isRef ? col.baseType : null,
-              // PHP parity: granted flag per column
-              granted: col.granted,
+              // PHP parity: ref = 1 (integer) for reference columns
+              ref: col.isRef ? 1 : null,
+              // PHP parity: granted = 1 (integer) only when granted, omitted otherwise
+              ...(col.granted ? { granted: 1 } : {}),
             },
             alias: col.alias,
           });
@@ -11408,18 +11406,31 @@ router.all('/:db/report/:reportId?', async (req, res) => {
                 format: 'CHARS',
                 align: 'LEFT',
                 totals: null,
-                ref: col.isRef ? col.baseType : null,
+                ref: col.isRef ? 1 : null,
               },
               alias: col.alias + '_id',
             });
           }
         }
         const cols = colEntries.map(e => e.def);
-        // Column-major: data[column_index] = [row0_val, row1_val, ...]
-        const data = colEntries.map(e =>
-          results.data.map(row => row[e.alias] !== undefined ? row[e.alias] : '')
-        );
-        return res.json({ columns: cols, data, rownum: results.rownum });
+        // PHP parity: rows is an object keyed by row index (string keys "0","1",...),
+        // each row is an object keyed by column ID → value
+        const rows = {};
+        for (let idx = 0; idx < results.data.length; idx++) {
+          const row = results.data[idx];
+          const r = {};
+          for (const e of colEntries) {
+            r[String(e.def.id)] = row[e.alias] !== undefined ? row[e.alias] : '';
+          }
+          rows[String(idx)] = r;
+        }
+        return res.json({
+          columns: cols,
+          rows,
+          totalCount: results.data.length,
+          header: report.header || '',
+          footer: [],
+        });
       }
 
       // Non-API (browser) fallback — report.html reads json.columns and row-major json.data


### PR DESCRIPTION
## Summary
- Restructured default `?JSON` report response from column-major `data` array to row-major `rows` object with string keys, matching PHP format
- Renamed `rownum` to `totalCount`
- Added `header` (report title) and `footer` (empty array) fields
- Changed `granted` from boolean to integer `1` (only present when granted), `type` from string to integer, `ref` from baseType to integer `1`

Fixes #387

## Test plan
- [x] Existing vitest suite passes (49/49 tests)
- [ ] Verify `?JSON` response matches PHP format: `{columns, rows, totalCount, header, footer}`
- [ ] Verify `rows` is row-major object with string keys (`"0"`, `"1"`, ...)
- [ ] Verify `granted` is integer `1` (not boolean `true`)
- [ ] Verify `type` is integer (not string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)