### PR TITLE
fix: change GET auth id from Number to String (#383)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -3131,7 +3131,7 @@ router.get('/:db/auth', async (req, res, next) => {
     if (rows.length === 0) return res.status(200).json([{ error: t9n('not_logged', locale) }]);
     const u = rows[0];
     const xsrf = u.xsrf_val || generateXsrf(token, u.uname || '', db);
-    return res.status(200).json({ _xsrf: xsrf, token, id: Number(u.uid), msg: '' });
+    return res.status(200).json({ _xsrf: xsrf, token, id: String(u.uid), msg: '' });
   } catch (err) {
     logger.error('[GET /:db/auth] DB error', { error: err.message, db });
     return res.status(200).json([{ error: t9n('server_error', locale) }]);


### PR DESCRIPTION
## Summary
- Changed `id: Number(u.uid)` to `id: String(u.uid)` in `GET /:db/auth` response (line 3134)
- PHP's `mysqli_fetch_array` returns all values as strings; `json_encode` preserves string type → `"id":"123"`
- The POST auth endpoint already uses `String(user.uid)` — this aligns the GET handler for consistency

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)