### PR TITLE
fix: add Content-Disposition/Content-Transfer-Encoding to JSON responses (#382)

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
+++ b/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
@@ -1226,3 +1226,52 @@ describe('updateTokens activity timestamp format (#329)', () => {
     expect(actTimestamp).toMatch(/\./);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// api_dump() headers (Issue #382)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('api_dump() headers (Issue #382)', () => {
+  const app = makeApp();
+  const token = 'test-token-abc';
+  const xsrf  = generateXsrf(token, DB, DB);
+  const pwdHash = phpCompatibleHash('alice', 'Password1!', DB);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('JSON responses include Content-Disposition and Content-Transfer-Encoding', async () => {
+    const showTablesResp = [[{ Tables_in_integram: DB }]];
+    const userRow = { uid: 5, username: 'alice', password_hash: pwdHash, pwd_id: 6, token, token_id: 7, xsrf, xsrf_id: 8 };
+    const userResp = [[userRow]];
+    const updateResp = [{ affectedRows: 1 }];
+
+    mockQuery(showTablesResp, userResp, updateResp, updateResp);
+
+    const res = await request(app)
+      .post(`/${DB}/auth?JSON`)
+      .send({ login: 'alice', pwd: 'Password1!' });
+
+    expect(res.status).toBe(200);
+    // PHP api_dump() sets Content-Disposition: attachment;filename=api.json
+    expect(res.headers['content-disposition']).toBe('attachment;filename=api.json');
+    // PHP api_dump() sets Content-Transfer-Encoding: binary
+    expect(res.headers['content-transfer-encoding']).toBe('binary');
+  });
+
+  it('non-JSON requests do not get api_dump headers', async () => {
+    const showTablesResp = [[{ Tables_in_integram: DB }]];
+    const userRow = { uid: 5, username: 'alice', password_hash: pwdHash, pwd_id: 6, token, token_id: 7, xsrf, xsrf_id: 8 };
+    const userResp = [[userRow]];
+    const updateResp = [{ affectedRows: 1 }];
+
+    mockQuery(showTablesResp, userResp, updateResp, updateResp);
+
+    // POST without ?JSON → redirect (non-JSON response)
+    const res = await request(app)
+      .post(`/${DB}/auth`)
+      .send({ login: 'alice', pwd: 'Password1!' });
+
+    // Redirect responses should NOT have api_dump headers
+    expect(res.headers['content-transfer-encoding']).toBeUndefined();
+  });
+});

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -254,6 +254,26 @@ const router = express.Router();
 // This middleware ensures all JSON responses have keys sorted alphabetically.
 router.use(phpJsonMiddleware());
 
+// PHP api_dump() headers middleware (Issue #382)
+// PHP's api_dump() (index.php:7448) calls sendJsonHeaders() which sets
+// Content-Disposition and Content-Transfer-Encoding on ALL JSON responses.
+// Express res.json() only sets Content-Type; this middleware adds the missing
+// headers to match PHP behavior for clients that rely on them.
+router.use((req, res, next) => {
+  const originalJson = res.json.bind(res);
+  res.json = function apiDumpJson(body) {
+    // Only add headers if not already set (e.g. file downloads set their own)
+    if (!res.getHeader('Content-Disposition')) {
+      res.setHeader('Content-Disposition', 'attachment;filename=api.json');
+    }
+    if (!res.getHeader('Content-Transfer-Encoding')) {
+      res.setHeader('Content-Transfer-Encoding', 'binary');
+    }
+    return originalJson(body);
+  };
+  next();
+});
+
 // Skip API v2 paths — let them fall through to the V2 router mounted in start.js.
 // Without this, the legacy /:db/auth and /:db POST handlers intercept
 // /api/v2/auth (where db="v2") and fail with "v2 does not exist".


### PR DESCRIPTION
## Summary

- Add router-level middleware to set `Content-Disposition: attachment;filename=api.json` and `Content-Transfer-Encoding: binary` on all JSON responses, matching PHP's `api_dump()` / `sendJsonHeaders()` behavior (index.php:7448/3963)
- Add tests verifying the headers are present on JSON API responses and absent on non-JSON (redirect) responses

## Details

PHP's `api_dump()` calls `sendJsonHeaders()` which sets three headers on every JSON response:
- `Content-Type: application/json; charset=UTF-8`
- `Content-Disposition: attachment;filename=<name>`
- `Content-Transfer-Encoding: binary`

Express `res.json()` only sets `Content-Type`. The middleware intercepts `res.json()` to add the two missing headers before the response is sent. Headers already set by specific routes (e.g. file download endpoints) are preserved via `res.getHeader()` guard.

Fixes #382

## Test plan

- [ ] Verify JSON API responses include `Content-Disposition: attachment;filename=api.json`
- [ ] Verify JSON API responses include `Content-Transfer-Encoding: binary`
- [ ] Verify non-JSON responses (redirects) do not include these headers
- [ ] Verify file download routes that set their own `Content-Disposition` are not overwritten