### PR TITLE
fix: JSON_DATA empty array (#441)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -8900,10 +8900,10 @@ router.post('/:db/_d_new/:parentTypeId?', legacyAuthMiddleware, legacyXsrfCheck,
       return res.status(200).json([{ error: `Base type is invalid: ${baseType}` }]);
     }
 
-    // PHP line 8636-8641: duplicate (val, t) check at root level
+    // PHP line 8636-8641: duplicate (val, t) check — PHP always checks since types always have up=0
     // SELECT id FROM $z WHERE val='...' AND t=$t AND id!=t
     // If duplicate found: return existing id with warning (not an error)
-    if (parentId === 0) {
+    {
       const pool = getPool();
       const { rows: dupeRows } = await execSql(pool, `SELECT id FROM \`${db}\` WHERE val = ? AND t = ? AND id != t LIMIT 1`, [name, baseType], { label: 'post_db_d_new_parentTypeId_select' });
       if (dupeRows.length > 0) {
@@ -8919,13 +8919,11 @@ router.post('/:db/_d_new/:parentTypeId?', legacyAuthMiddleware, legacyXsrfCheck,
     // PHP line 7788: $unique = isset($_REQUEST["unique"]) ? 1 : 0
     // PHP line 8327: "Ord=1 means the Obj must be unique" — for root-level types (up=0) ord IS the unique flag
     // PHP _d_new: Insert(0, $unique, $t, $val) — always inserts at up=0, ord = unique flag (0 or 1)
-    // For child types (parentId != 0, Node.js extension), use sequential ord via getNextOrder
-    const order = (parentId === 0)
-      ? ((req.body.unique !== undefined || req.query.unique !== undefined) ? 1 : 0)
-      : await getNextOrder(db, parentId);
+    // PHP always uses up=0 for type meta rows regardless of parentId parameter (#441)
+    const order = (req.body.unique !== undefined || req.query.unique !== undefined) ? 1 : 0;
 
-    // Insert the new type
-    const id = await insertRow(db, parentId, order, baseType, name);
+    // Insert the new type — PHP always uses up=0 for the type meta row
+    const id = await insertRow(db, 0, order, baseType, name);
 
     logger.info('[Legacy _d_new] Type created', { db, id, name, baseType, parentId });
 

--- a/tests/integration/json-data-441.js
+++ b/tests/integration/json-data-441.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Regression test for issue #441:
+ * JSON_DATA returns empty array instead of actual data.
+ *
+ * Root cause: _d_new created types with up=parentId instead of up=0 (PHP parity),
+ * which caused _m_new type-existence check (WHERE up=0) to fail, so no objects
+ * were ever created via Node, and JSON_DATA returned [].
+ *
+ * This test verifies:
+ * 1. _d_new creates types with up=0 (type meta row, matching PHP)
+ * 2. _m_new can create objects against Node-created types
+ * 3. JSON_DATA returns actual object data (not empty array)
+ */
+import h from './lib/helpers.js';
+const TS = Date.now();
+const PREFIX = `__441_`;
+
+async function run() {
+  await h.setup();
+  console.log(`Token: ${h.token.slice(0, 8)}...`);
+
+  h.section('Issue #441: JSON_DATA returns actual data');
+
+  // 1. Create type via Node (with up=1 in body, like the comparison test does)
+  const typeRes = await h.http(
+    h.NODE, 'POST', `/${h.DB}/_d_new`,
+    `_xsrf=${h.xsrfNode}&val=${PREFIX}type_${TS}&t=3&up=1&JSON=1`,
+    h.cookie()
+  );
+  const typeId = Number(typeRes.json?.obj);
+  {
+    const issues = [];
+    if (!typeId || typeId <= 0) issues.push(`Type creation failed: ${typeRes.body}`);
+    h.report('1. _d_new creates type via Node', issues);
+  }
+  if (!typeId || typeId <= 0) {
+    console.error('Cannot continue without type');
+    h.summary('Issue #441 — JSON_DATA');
+  }
+
+  // 2. Verify type has up=0 (PHP parity) by checking _m_new can find it
+  const objRes = await h.http(
+    h.NODE, 'POST', `/${h.DB}/_m_new/${typeId}`,
+    `_xsrf=${h.xsrfNode}&up=1&t${typeId}=Alpha&JSON=1`,
+    h.cookie()
+  );
+  const objId = Number(objRes.json?.obj || objRes.json?.id);
+  {
+    const issues = [];
+    if (!objId || objId <= 0) issues.push(`Object creation failed: ${objRes.body}`);
+    if (objRes.json?.error) issues.push(`Error: ${objRes.json.error}`);
+    h.report('2. _m_new creates object against Node-created type', issues);
+  }
+
+  // 3. Create more objects
+  const objIds = [objId];
+  for (const val of ['Beta', 'Gamma', 'Delta', 'Epsilon']) {
+    const r = await h.http(
+      h.NODE, 'POST', `/${h.DB}/_m_new/${typeId}`,
+      `_xsrf=${h.xsrfNode}&up=1&t${typeId}=${val}&JSON=1`,
+      h.cookie()
+    );
+    const id = Number(r.json?.obj || r.json?.id);
+    if (id > 0) objIds.push(id);
+  }
+  {
+    const issues = [];
+    if (objIds.filter(id => id > 0).length !== 5) {
+      issues.push(`Expected 5 objects, got ${objIds.filter(id => id > 0).length}`);
+    }
+    h.report('3. Created 5 objects total', issues);
+  }
+
+  // 4. GET /object/:typeId?JSON_DATA — the core test
+  const jsonDataRes = await h.http(
+    h.NODE, 'GET', `/${h.DB}/object/${typeId}?JSON_DATA`,
+    null, h.cookie()
+  );
+  {
+    const issues = [];
+    if (jsonDataRes.status !== 200) issues.push(`Status ${jsonDataRes.status}`);
+    if (!Array.isArray(jsonDataRes.json)) {
+      issues.push(`Expected array, got ${typeof jsonDataRes.json}`);
+    } else if (jsonDataRes.json.length === 0) {
+      issues.push(`JSON_DATA returned empty array [] — THIS IS THE BUG`);
+    } else if (jsonDataRes.json.length !== 5) {
+      issues.push(`Expected 5 items, got ${jsonDataRes.json.length}`);
+    }
+    // Check compact format: {i, u, o, r}
+    if (Array.isArray(jsonDataRes.json) && jsonDataRes.json.length > 0) {
+      const first = jsonDataRes.json[0];
+      if (first.i === undefined) issues.push('Missing "i" (id) field');
+      if (first.u === undefined) issues.push('Missing "u" (up) field');
+      if (first.o === undefined) issues.push('Missing "o" (ord) field');
+      if (!Array.isArray(first.r)) issues.push('Missing "r" (reqs) array');
+      if (Array.isArray(first.r) && first.r.length === 0) issues.push('"r" array is empty (should have at least val)');
+    }
+    h.report('4. JSON_DATA returns actual data (not empty array)', issues);
+  }
+
+  // 5. Verify JSON_DATA format matches PHP compact format
+  {
+    const issues = [];
+    if (Array.isArray(jsonDataRes.json) && jsonDataRes.json.length > 0) {
+      const vals = jsonDataRes.json.map(item => item.r?.[0]).sort();
+      const expected = ['Alpha', 'Beta', 'Delta', 'Epsilon', 'Gamma'];
+      const valsSorted = [...vals].sort();
+      if (JSON.stringify(valsSorted) !== JSON.stringify(expected)) {
+        issues.push(`Values mismatch: got [${valsSorted}] expected [${expected}]`);
+      }
+      // All should have u=1 (root parent)
+      for (const item of jsonDataRes.json) {
+        if (item.u !== 1) {
+          issues.push(`Object ${item.i} has u=${item.u}, expected u=1`);
+          break;
+        }
+      }
+    } else {
+      issues.push('No data to verify format');
+    }
+    h.report('5. JSON_DATA values match created objects', issues);
+  }
+
+  // 6. Compare PHP vs Node JSON_DATA
+  // Create same type+objects via PHP for comparison
+  const phpTypeRes = await h.http(
+    h.PHP, 'POST', `/${h.DB}/_d_new`,
+    `_xsrf=${h.xsrfPhp}&val=${PREFIX}php_${TS}&t=3&up=1&JSON=1`,
+    h.cookie()
+  );
+  const phpTypeId = Number(phpTypeRes.json?.obj);
+  if (phpTypeId > 0) {
+    for (const val of ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']) {
+      await h.http(
+        h.PHP, 'POST', `/${h.DB}/_m_new/${phpTypeId}`,
+        `_xsrf=${h.xsrfPhp}&up=1&t${phpTypeId}=${val}&JSON=1`,
+        h.cookie()
+      );
+    }
+    const phpJsonData = await h.http(
+      h.PHP, 'GET', `/${h.DB}/object/${phpTypeId}?JSON_DATA`,
+      null, h.cookie()
+    );
+    const nodeJsonData = jsonDataRes;
+    const issues = [];
+    if (!Array.isArray(phpJsonData.json)) {
+      issues.push(`PHP returned non-array: ${h.short(phpJsonData.body, 80)}`);
+    } else if (phpJsonData.json.length !== (nodeJsonData.json?.length || 0)) {
+      issues.push(`Count mismatch: PHP=${phpJsonData.json.length} Node=${nodeJsonData.json?.length || 0}`);
+    } else {
+      // Check structure matches
+      if (phpJsonData.json.length > 0 && nodeJsonData.json.length > 0) {
+        const phpKeys = Object.keys(phpJsonData.json[0]).sort().join(',');
+        const nodeKeys = Object.keys(nodeJsonData.json[0]).sort().join(',');
+        if (phpKeys !== nodeKeys) issues.push(`Structure mismatch: PHP=[${phpKeys}] Node=[${nodeKeys}]`);
+      }
+    }
+    h.report('6. PHP vs Node JSON_DATA parity (same count + structure)', issues);
+
+    // Cleanup PHP type
+    await h.http(h.PHP, 'POST', `/${h.DB}/_d_del/${phpTypeId}`,
+      `_xsrf=${h.xsrfPhp}&forced=1&JSON=1`, h.cookie());
+  } else {
+    h.skip('6. PHP vs Node JSON_DATA parity', 'PHP type creation failed');
+  }
+
+  // Cleanup Node type
+  await h.http(h.NODE, 'POST', `/${h.DB}/_d_del/${typeId}`,
+    `_xsrf=${h.xsrfNode}&forced=1&JSON=1`, h.cookie());
+
+  h.summary('Issue #441 — JSON_DATA');
+}
+
+run().catch(e => { console.error(e); process.exit(2); });


### PR DESCRIPTION
## Summary

- **Root cause**: `_d_new` created type meta rows with `up=parentId` instead of `up=0`. PHP always uses `Insert(0, $unique, $t, $val)` — hardcoding `up=0` for all type meta rows. Node was incorrectly using the `parentId` parameter.
- This caused `_m_new`'s type-existence check (`WHERE id=? AND up=0`) to fail silently, so objects were never created via Node, and `JSON_DATA` returned `[]`.
- Fix: `_d_new` now always inserts types with `up=0` and runs the duplicate check unconditionally, matching PHP behavior.

## Test plan

- [ ] Run `node tests/integration/json-data-441.js` — verifies type creation, object creation, and JSON_DATA response
- [ ] Run `node tests/comparison/04-listing.js` — test #2 (JSON_DATA) should now return 5 items instead of 0
- [ ] Verify `_d_new` creates types with `up=0` regardless of `up` parameter in request body

Fixes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)