### PR TITLE
fix: DML array vs object response format (#439)

### DIFF
--- a/backend/monolith/src/api/routes/__tests__/dml-response-format.test.js
+++ b/backend/monolith/src/api/routes/__tests__/dml-response-format.test.js
@@ -1,0 +1,178 @@
+/**
+ * DML Response Format Parity Tests (Issue #439)
+ *
+ * Verifies that DML endpoints (_m_new, _m_save, _m_del, _m_up, _m_ord, _m_move, _m_id)
+ * have the correct response format matching PHP behavior:
+ *
+ * - Success: bare object via legacyRespond / res.json({...}) — not wrapped in array
+ * - my_die() errors: [{error:"..."}] (array format matches PHP my_die)
+ * - die()/exit() validation errors: plain text via res.send() (not JSON)
+ *
+ * These tests verify the response format by inspecting the source code patterns,
+ * since the DML routes require complex auth/XSRF mock setup for HTTP-level testing.
+ *
+ * PHP source references:
+ * - api_dump (line 7448): success JSON object
+ * - my_die (line 985): [{error:"msg"}] for API requests
+ * - die("text") / exit("text"): plain text for validation guards
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(__dirname, '..', 'legacy-compat.js'), 'utf-8');
+
+// ─── Helper: extract a route handler's source code ──────────────────────────
+
+function getRouteSection(endpoint) {
+  // Find the route definition and extract until next router.post/router.get or EOF
+  const patterns = {
+    '_m_id': /router\.post\([^)]*_m_id[^)]*\)/,
+    '_m_ord': /router\.post\([^)]*_m_ord[^)]*\)/,
+    '_m_move': /router\.post\([^)]*_m_move[^)]*\)/,
+    '_m_del': /router\.post\([^)]*_m_del[^)]*\)/,
+    '_m_save': /router\.post\([^)]*_m_save[^)]*\)/,
+    '_m_up': /router\.post\([^)]*_m_up[^)]*\)/,
+    '_m_new': /router\.post\([^)]*_m_new[^)]*\)/,
+  };
+
+  const startMatch = SRC.match(patterns[endpoint]);
+  if (!startMatch) return '';
+  const startIdx = startMatch.index;
+
+  // Find the next router definition after this one
+  const rest = SRC.slice(startIdx + 10);
+  const nextRoute = rest.match(/\nrouter\.(post|get|put|delete|all)\(/);
+  const endIdx = nextRoute ? startIdx + 10 + nextRoute.index : SRC.length;
+
+  return SRC.slice(startIdx, endIdx);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DML Response Format Parity (Issue #439)', () => {
+
+  describe('_m_id — validation errors return plain text (PHP: die("Invalid ID"))', () => {
+    const section = getRouteSection('_m_id');
+
+    it('returns res.send("Invalid ID") for invalid new_id, not res.json([{error}])', () => {
+      // PHP line 8842-8843: die("Invalid ID") — plain text
+      expect(section).toContain("res.status(200).send('Invalid ID')");
+      expect(section).not.toMatch(/json\(\[\{.*error.*new_id must be a positive integer/);
+    });
+
+    it('returns [{error}] for "This id belongs to metadata" (PHP: my_die)', () => {
+      // PHP line 8848-8849: my_die("This id belongs to metadata") → [{error}]
+      expect(section).toContain("'This id belongs to metadata'");
+      expect(section).toMatch(/json\(\[\{.*error.*This id belongs to metadata/s);
+    });
+
+    it('returns [{error}] for "The new id is occupied" (PHP: my_die)', () => {
+      // PHP line 8850-8851: my_die("The new id is occupied") → [{error}]
+      expect(section).toContain("'The new id is occupied'");
+      expect(section).toMatch(/json\(\[\{.*error.*The new id is occupied/s);
+    });
+  });
+
+  describe('_m_ord — validation errors return plain text (PHP: die("Invalid order"))', () => {
+    const section = getRouteSection('_m_ord');
+
+    it('returns res.send("Invalid order") for invalid order param', () => {
+      // PHP line 7822-7823: die("Invalid order") — plain text
+      expect(section).toContain("res.status(200).send('Invalid order')");
+    });
+  });
+
+  describe('_m_move — validation errors return plain text (PHP: die/exit)', () => {
+    const section = getRouteSection('_m_move');
+
+    it('returns plain text "Wrong id: ..." for id=0 (PHP: die line 8239)', () => {
+      // PHP line 8238-8239: die("Wrong id: $id") — plain text
+      expect(section).toMatch(/res\.status\(200\)\.send\(`Wrong id: \$\{id\}`\)/);
+    });
+
+    it('returns plain text "Cannot update meta-data" (PHP: exit line 8260)', () => {
+      expect(section).toContain("res.status(200).send('Cannot update meta-data')");
+    });
+
+    it('returns plain text "No such record" when object/parent not found (PHP: exit line 8271)', () => {
+      expect(section).toContain("res.status(200).send('No such record')");
+    });
+
+    it('returns plain text for types mismatch (PHP: exit line 8262)', () => {
+      expect(section).toMatch(/res\.status\(200\)\.send\(`Types mismatch/);
+    });
+  });
+
+  describe('_m_del — error format parity', () => {
+    const section = getRouteSection('_m_del');
+
+    it('returns [{error}] for wrong id=0 (PHP: my_die line 8277)', () => {
+      // PHP: my_die("Wrong id: $id") → [{error}]
+      expect(section).toMatch(/json\(\[\{.*error.*Wrong id/s);
+    });
+
+    it('returns plain text "Object not found" (PHP: die line 8306)', () => {
+      expect(section).toContain("res.status(200).send('Object not found')");
+    });
+
+    it('returns [{error}] for metadata deletion (PHP: my_die line 8288)', () => {
+      expect(section).toMatch(/json\(\[\{.*error.*can't delete metadata/s);
+    });
+
+    it('success path uses legacyRespond (bare object)', () => {
+      expect(section).toContain('legacyRespond(req, res, db,');
+    });
+  });
+
+  describe('_m_save — error format parity', () => {
+    const section = getRouteSection('_m_save');
+
+    it('returns plain text "No such record" (PHP: exit line 7999)', () => {
+      expect(section).toContain("res.status(200).send('No such record')");
+    });
+
+    it('returns plain text "Cannot update meta-data" (PHP: exit line 8001)', () => {
+      expect(section).toContain("res.status(200).send('Cannot update meta-data')");
+    });
+
+    it('success path uses legacyRespond (bare object)', () => {
+      expect(section).toContain('legacyRespond(req, res, db,');
+    });
+  });
+
+  describe('_m_up — error format parity', () => {
+    const section = getRouteSection('_m_up');
+
+    it('returns plain text "No arr recs" when object not found (PHP: exit line 7816)', () => {
+      expect(section).toContain("res.status(200).send('No arr recs')");
+    });
+
+    it('success path uses legacyRespond (bare object)', () => {
+      expect(section).toContain('legacyRespond(req, res, db,');
+    });
+  });
+
+  describe('_m_new — success returns bare object', () => {
+    const section = getRouteSection('_m_new');
+
+    it('success path returns res.json({...}) bare object (not array)', () => {
+      // PHP line 8546-8547: die("{\"id\":...}") — bare JSON object
+      expect(section).toMatch(/return res\.json\(\{ id.*obj.*ord.*next_act.*args.*val/);
+    });
+  });
+
+  describe('legacyRespond returns bare object (not array)', () => {
+    it('legacyRespond sends { id, obj, next_act, args, warnings } as bare object', () => {
+      // The function body should return res.json({...}), not res.json([{...}])
+      const funcMatch = SRC.match(/function legacyRespond[\s\S]*?^}/m);
+      expect(funcMatch).toBeTruthy();
+      const funcBody = funcMatch[0];
+      expect(funcBody).toContain('res.json({ id, obj, next_act');
+      expect(funcBody).not.toContain('res.json([');
+    });
+  });
+});

--- a/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
+++ b/backend/monolith/src/api/routes/__tests__/legacy-compat.test.js
@@ -537,16 +537,17 @@ describe('POST /:db/_m_id/:id', () => {
       .send({ new_id: '999' });
 
     expect(res.status).toBe(200);
-    expect(res.body[0].error).toMatch(/already in use/i);
+    expect(res.body[0].error).toMatch(/occupied/i);
   });
 
-  it('returns error when new_id is missing', async () => {
+  it('returns plain text "Invalid ID" when new_id is missing (PHP: die("Invalid ID"))', async () => {
     const res = await request(app)
       .post(`/${DB}/_m_id/100`)
       .send({});
 
     expect(res.status).toBe(200);
-    expect(res.body[0].error).toMatch(/positive integer/i);
+    // PHP: die("Invalid ID") — plain text, not JSON array
+    expect(res.text).toBe('Invalid ID');
   });
 });
 

--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -7055,12 +7055,13 @@ router.post('/:db/_m_save/:id', legacyAuthMiddleware, legacyXsrfCheck, (req, res
     let warnings = '';
 
     // Existence check + metadata protection
+    // PHP: exit("No such record") and exit("Cannot update meta-data") — plain text (index.php:7999,8001)
     const { rows: existCheck } = await execSql(pool, `SELECT id, up FROM \`${db}\` WHERE id = ? LIMIT 1`, [originalId], { label: 'post_db_m_save_id_select' });
     if (existCheck.length === 0) {
-      return res.status(200).json([{ error: 'Object not found' }]);
+      return res.status(200).send('No such record');
     }
     if (existCheck[0].up === 0) {
-      return res.status(200).json([{ error: 'Cannot modify metadata object' }]);
+      return res.status(200).send('Cannot update meta-data');
     }
 
     // Grant check — PHP checks WRITE grant before saving
@@ -7507,7 +7508,8 @@ router.post('/:db/_m_del/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req
        WHERE obj.id = ?`, [objectId], { label: 'post_db_m_del_id_select' });
 
     if (!row || row.pup == null) {
-      return res.status(200).json([{ error: 'Object not found' }]);
+      // PHP: die("Object not found") — plain text (index.php:8306)
+      return res.status(200).send('Object not found');
     }
 
     // PHP: if pup==0 → can't delete metadata
@@ -7749,10 +7751,15 @@ router.post('/:db/_m_move/:id', legacyAuthMiddleware, legacyXsrfCheck, async (re
     const objectId = parseInt(id, 10);
     const newParentId = parseInt(req.body.up, 10);
 
+    // PHP: die("Wrong id: $id") — plain text (index.php:8238-8239)
+    if (!objectId) {
+      return res.status(200).send(`Wrong id: ${id}`);
+    }
+
     const pool = getPool();
     const { grants, username } = req.legacyUser || {};
 
-    // Grant check on source object and target parent
+    // Grant check on source object — PHP: Check_Grant($id) uses my_die format
     if (!await checkGrant(pool, db, grants || {}, objectId, 0, 'WRITE', username || '')) {
       return res.status(200).json([{ error: 'Insufficient privileges' }]);
     }
@@ -7763,15 +7770,16 @@ router.post('/:db/_m_move/:id', legacyAuthMiddleware, legacyXsrfCheck, async (re
     // Fetch full object info (t, up, ord) before moving
     const { rows: objInfo } = await execSql(pool, `SELECT t, up, ord FROM \`${db}\` WHERE id = ? LIMIT 1`, [objectId], { label: 'post_db_m_move_id_select' });
     if (objInfo.length === 0) {
-      return res.status(200).json([{ error: 'Object not found' }]);
+      // PHP: exit("No such record") — plain text (index.php:8271)
+      return res.status(200).send('No such record');
     }
     const objType = objInfo[0].t;
     const oldParentId = objInfo[0].up;
     const oldOrd = objInfo[0].ord;
 
-    // Metadata protection: can't move root-level types
+    // PHP: exit("Cannot update meta-data") — plain text (index.php:8260)
     if (oldParentId === 0) {
-      return res.status(200).json([{ error: 'Cannot move metadata object' }]);
+      return res.status(200).send('Cannot update meta-data');
     }
 
     // Type mismatch guard: old parent and new parent must be of the same type
@@ -7779,10 +7787,12 @@ router.post('/:db/_m_move/:id', legacyAuthMiddleware, legacyXsrfCheck, async (re
        FROM \`${db}\` old_p, \`${db}\` new_p
        WHERE old_p.id = ? AND new_p.id = ?`, [oldParentId, newParentId], { label: 'post_db_m_move_id_select' });
     if (parentRows.length === 0) {
-      return res.status(200).json([{ error: 'Parent not found' }]);
+      // PHP: exit("No such record") — plain text (index.php:8271)
+      return res.status(200).send('No such record');
     }
     if (parentRows[0].ut !== parentRows[0].tt) {
-      return res.status(200).json([{ error: `Types mismatch ${objType}!=${parentRows[0].tt}` }]);
+      // PHP: exit("Types mismatch ...") — plain text (index.php:8262)
+      return res.status(200).send(`Types mismatch ${objType}!=${parentRows[0].tt}`);
     }
 
     // Same-parent no-op: skip if already under the target parent
@@ -9654,9 +9664,10 @@ router.post('/:db/_m_up/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req,
     }
 
     // Get current object
+    // PHP: exit("No arr recs") — plain text (index.php:7816)
     const obj = await getObjectById(db, objectId);
     if (!obj) {
-      return res.status(404).json([{ error: 'Object not found' }]);
+      return res.status(200).send('No arr recs');
     }
 
     // Find the previous sibling (same parent and type, lower order)
@@ -9775,10 +9786,11 @@ router.post('/:db/_m_id/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req,
     const { grants, username } = req.legacyUser || {};
 
     if (!newId || newId <= 0) {
-      return res.status(200).json([{ error: 'new_id must be a positive integer' }]);
+      // PHP: die("Invalid ID") — plain text, not JSON (index.php:8843)
+      return res.status(200).send('Invalid ID');
     }
     if (oldId === newId) {
-      return res.status(200).json([{ error: 'new_id must differ from current id' }]);
+      return res.status(200).send('Invalid ID');
     }
 
     // Grant check — PHP checks WRITE grant before ID change
@@ -9793,15 +9805,19 @@ router.post('/:db/_m_id/:id', legacyAuthMiddleware, legacyXsrfCheck, async (req,
     }
     const up = objRows[0].up;
 
+    // PHP: SELECT up FROM $z WHERE id=$newId OR (id=$id AND up=0) — single query checks both
+    // If up===0, my_die("This id belongs to metadata"); if exists, my_die("The new id is occupied")
+    // Node splits into two queries for clarity but preserves my_die() [array] format
+
     // Metadata guard: can't change ID of metadata (root-level types)
     if (objRows[0].up === 0) {
-      return res.status(200).json([{ error: 'Cannot change ID of metadata object' }]);
+      return res.status(200).json([{ error: 'This id belongs to metadata' }]);
     }
 
     // Check that new_id is not already in use
     const { rows: existRows } = await execSql(pool, `SELECT id FROM \`${db}\` WHERE id = ? LIMIT 1`, [newId], { label: 'post_db_m_id_id_select' });
     if (existRows.length > 0) {
-      return res.status(200).json([{ error: `ID ${newId} is already in use` }]);
+      return res.status(200).json([{ error: 'The new id is occupied' }]);
     }
 
     // PHP: 3 UPDATEs to rename the id everywhere it appears — wrap in transaction


### PR DESCRIPTION
## Summary

- Align Node.js DML endpoint error responses with PHP behavior
- PHP `die()`/`exit()` validation errors now return **plain text** (was JSON `[{error}]` array)
- PHP `my_die()` errors keep the `[{error}]` array format (already correct)
- Error messages updated to match PHP wording exactly
- Added `id=0` guard to `_m_move` (PHP has it, Node was missing it)

### Affected endpoints
| Endpoint | Change |
|----------|--------|
| `_m_id` | `"Invalid ID"` plain text; metadata/occupied messages match PHP |
| `_m_save` | `"No such record"`, `"Cannot update meta-data"` plain text |
| `_m_del` | `"Object not found"` plain text |
| `_m_move` | `"Wrong id"`, `"No such record"`, `"Cannot update meta-data"`, `"Types mismatch"` plain text |
| `_m_up` | `"No arr recs"` plain text, status 200 (was 404) |

## Test plan

- [x] 19 new regression tests in `dml-response-format.test.js` — all pass
- [x] Updated existing `legacy-compat.test.js` assertions for `_m_id` format changes
- [x] No regression in existing test suite (59 pre-existing failures unchanged)

Fixes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)