### PR TITLE
fix: add missing &editables to edit_types response (#506)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -5756,13 +5756,10 @@ router.get('/:db/:page*', async (req, res, next) => {
           if (REV_BASE_TYPE[k]) { typBlock.typ.push(String(k)); typBlock.val.push(REV_BASE_TYPE[k]); }
         }
         // PHP: edit_types isApi() calls die() before myrolemenu/top_menu are added (#443)
-        // PHP: &Editables block sets ok=[""] only when Check_Types_Grant()=="WRITE",
-        // but the &Edit_Typs handler die()s at line 4316 which means &editables content
-        // was already processed by the template engine. However, testing shows PHP does NOT
-        // include &main.a.&editables in the JSON output — likely because the template engine
-        // only adds block data when it successfully iterates the block content, and &Editables
-        // processing may not populate the API vars in all cases. Match PHP: omit it.
+        // PHP: &Editables block sets ok=[""] when Check_Types_Grant()=="WRITE"
+        // PHP includes &main.a.&editables in the JSON output with ok:[""]
         return res.json({
+          '&main.a.&editables': { ok: [''] },
           '&main.a.&types':     typBlock,
           edit_types: editTypesET,
           types: REV_BASE_TYPE,


### PR DESCRIPTION
## Summary
- Add `&main.a.&editables: { ok: [''] }` to edit_types?JSON response matching PHP

## Test
```bash
node tests/comparison/06-admin.js
```

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)