### PR TITLE
fix: add _list/_list_join handlers to PHP (#507)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -7963,12 +7963,11 @@ router.all('/:db/_dict/:typeId?', legacyAuthMiddleware, async (req, res) => {
 });
 
 /**
- * _list - Get list of objects (NODE-ONLY, no PHP equivalent — see #451)
+ * _list - Get list of objects
  * GET/POST /:db/_list/:typeId
  * Parameters: up (parent), LIMIT, F (offset/from), q (search), sort, dir, f_0, f_{reqId}
  *
- * PHP returns `null` (plain text, 200) for this route (no handler).
- * Node returns newline-separated plain text: each line is "id\tval" (tab-separated).
+ * Returns newline-separated plain text: each line is "id\tval" (tab-separated).
  */
 router.all('/:db/_list/:typeId', legacyAuthMiddleware, async (req, res) => {
   const { db, typeId } = req.params;
@@ -8096,8 +8095,6 @@ router.all('/:db/_list/:typeId', legacyAuthMiddleware, async (req, res) => {
     }));
 
     // Return in PHP-compatible format: newline-separated plain text (id\tval per line)
-    // PHP has no _list handler and returns `null` for this route.
-    // Node returns the actual data as newline-separated text to match PHP's text format.
     const lines = objects.map(o => `${o.id}\t${o.val}`);
     res.type('text/html').send(lines.join('\n'));
   } catch (error) {
@@ -8107,12 +8104,11 @@ router.all('/:db/_list/:typeId', legacyAuthMiddleware, async (req, res) => {
 });
 
 /**
- * _list_join - List objects with multi-join queries (NODE-ONLY, no PHP equivalent — see #451)
+ * _list_join - List objects with multi-join queries
  * GET/POST /:db/_list_join/:typeId
  * Parameters: up (parent), LIMIT, F (offset/from), q (search), join (comma-separated requisite IDs to join)
  *
- * PHP returns `null` (plain text, 200) for this route (no handler).
- * Node returns newline-separated plain text: each line is "id\tval[\treq1\treq2\t...]" (tab-separated).
+ * Returns newline-separated plain text: each line is "id\tval[\treq1\treq2\t...]" (tab-separated).
  *
  * This endpoint supports complex multi-join queries that fetch object data
  * along with requisite values in a single query.

--- a/integram-server/index.php
+++ b/integram-server/index.php
@@ -8950,6 +8950,65 @@ if(Validate_Token())
 	        api_dump($json, "terms.json");
 		    break;
 
+		case "_list":
+		    # Return objects of type $id as plain text: id\tval per line
+		    if((int)$id === 0)
+		        die("null");
+		    $limit = isset($_REQUEST["LIMIT"]) ? (int)$_REQUEST["LIMIT"] : 50;
+		    $offset = isset($_REQUEST["F"]) ? (int)$_REQUEST["F"] : 0;
+		    $search_cond = "";
+		    if(isset($_REQUEST["q"]) && strlen($_REQUEST["q"])){
+		        $q = addslashes($_REQUEST["q"]);
+		        $search_cond = " AND (a.val LIKE '%$q%' OR EXISTS (SELECT 1 FROM $z req WHERE req.up=a.id AND req.val LIKE '%$q%'))";
+		    }
+		    $up_cond = "";
+		    if(isset($_REQUEST["up"]) && is_numeric($_REQUEST["up"]))
+		        $up_cond = " AND a.up=".(int)$_REQUEST["up"];
+		    $data_set = Exec_sql("SELECT a.id, a.val FROM $z a WHERE a.t=$id $search_cond $up_cond ORDER BY a.ord LIMIT $limit OFFSET $offset"
+		                        , "List objects");
+		    $lines = array();
+		    while($row = mysqli_fetch_array($data_set))
+		        $lines[] = $row["id"]."\t".$row["val"];
+		    die(implode("\n", $lines));
+		    break;
+
+		case "_list_join":
+		    # Return objects of type $id with requisite values as plain text: id\tval[\treq_val...] per line
+		    if((int)$id === 0)
+		        die("null");
+		    $limit = isset($_REQUEST["LIMIT"]) ? (int)$_REQUEST["LIMIT"] : 50;
+		    $offset = isset($_REQUEST["F"]) ? (int)$_REQUEST["F"] : 0;
+		    $search_cond = "";
+		    if(isset($_REQUEST["q"]) && strlen($_REQUEST["q"])){
+		        $q = addslashes($_REQUEST["q"]);
+		        $search_cond = " AND obj.val LIKE '%$q%'";
+		    }
+		    $up_cond = "";
+		    if(isset($_REQUEST["up"]) && is_numeric($_REQUEST["up"]))
+		        $up_cond = " AND obj.up=".(int)$_REQUEST["up"];
+		    # Get type requisites for join (first 5)
+		    $req_data = Exec_sql("SELECT id, val, t FROM $z WHERE up=$id ORDER BY ord LIMIT 5", "Get type reqs for join");
+		    $select_parts = array("obj.id", "obj.val");
+		    $join_parts = array();
+		    $join_idx = 0;
+		    while($req_row = mysqli_fetch_array($req_data)){
+		        $alias = "r".$join_idx++;
+		        $select_parts[] = "$alias.val AS ".$alias."val";
+		        $join_parts[] = "LEFT JOIN $z $alias ON $alias.up=obj.id AND $alias.t=".$req_row["id"];
+		    }
+		    $sql = "SELECT ".implode(", ", $select_parts)." FROM $z obj ".implode(" ", $join_parts)
+		          ." WHERE obj.t=$id $search_cond $up_cond ORDER BY obj.ord LIMIT $limit OFFSET $offset";
+		    $data_set = Exec_sql($sql, "List objects with join");
+		    $lines = array();
+		    while($row = mysqli_fetch_array($data_set)){
+		        $parts = array($row["id"], $row["val"]);
+		        for($i = 0; $i < $join_idx; $i++)
+		            $parts[] = isset($row["r".$i."val"]) ? $row["r".$i."val"] : "";
+		        $lines[] = implode("\t", $parts);
+		    }
+		    die(implode("\n", $lines));
+		    break;
+
 		case "_ref_reqs":
 		    if((int)$id === 0)
 		        die("{\"error\":\"Invalid id\"}");


### PR DESCRIPTION
## Summary
- **PHP had no `_list`/`_list_join` handlers** — requests fell through to default case returning `null`
- Added proper PHP handlers returning tab-separated text (`id\tval` per line)
- `_list_join` also LEFT JOINs first 5 requisites
- Updated Node comments removing "Node-only" notes

## Test
```bash
node tests/comparison/04-listing.js
node tests/comparison/07-refs-multi.js
```

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)