### PR TITLE
fix: edit_obj disabled key + val duplication (#505)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -6142,8 +6142,9 @@ router.get('/:db/:page*', async (req, res, next) => {
             typ:      [String(obj.t), String(obj.t)],
             up:       [String(obj.up)],
             typ_name: [objTypName, objTypName],
-            val:      [obj.val || ''],
+            val:      [obj.val || '', obj.val || ''],
             id:       [String(obj.id)],
+            disabled: [''],
           },
           '&main.a.&object.&edit_req': {
             type:                ['text'],


### PR DESCRIPTION
## Summary
- Add `disabled: ['']` to `&main.a.&object` matching PHP template `{DISABLED}`
- Duplicate `val` array (2 elements) matching PHP's case-sensitive `array_unique`

## Test
```bash
node tests/comparison/04-listing.js
node tests/comparison/07-refs-multi.js
```

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)