### PR TITLE
fix: PHP→Node parity for GET /object?JSON (#514)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -5100,7 +5100,8 @@ router.get('/:db/:page*', async (req, res, next) => {
           objWhereParts.push('a.val LIKE ?');
           objWhereParams.push(vp);
         }
-        if (filterUp !== null && !isNaN(filterUp)) {
+        // PHP: F_U=0 means "show all non-root" (no parent filter); F_U>0 filters by parent
+        if (filterUp !== null && !isNaN(filterUp) && filterUp > 0) {
           objWhereParts.push('a.up = ?');
           objWhereParams.push(filterUp);
         }
@@ -5672,20 +5673,35 @@ router.get('/:db/:page*', async (req, res, next) => {
           }
         }
 
+        // PHP #514: When F_U > 0 and no objects found, return simplified _noobj response
+        // PHP's template engine skips &Uni_obj and all sub-blocks when SQL returns 0 rows
+        // with a parent filter, resulting in only &main.a and &main.a._noobj
+        if (filterUp !== null && filterUp > 0 && objRows.length === 0) {
+          const noObjResponse = {
+            '&main.a': { '_parent_.title': [typeVal] },
+            '&main.a._noobj': { '_request_.f_u': [String(filterUp)] },
+          };
+          return res.json(noObjResponse);
+        }
+
         // Note: PHP does not include 'total' in object JSON response.
         // objTotal is still used below for pagination (&no_page block).
         // PHP #419: cur_base_typ is the type's own base type, not each row's type
         const curBaseTypId = typeRow ? typeRow.base_type_id : 3;
         const includeRef = (curBaseTypId === TYPE.REPORT_COLUMN || curBaseTypId === TYPE.GRANT);
-        response['object']                             = objRows.map(r => {
-          const obj = { id: String(r.id), val: r.val, up: String(r.up), base: String(r.base) };
-          // PHP #418: include ord when viewing child objects (f_u > 1)
-          if (fuParam && parseInt(fuParam, 10) > 1) obj.ord = String(r.ord || 0);
-          // PHP #419: include ref (raw val) for REPORT_COLUMN and GRANT base types
-          if (includeRef) obj.ref = r.val || '';
-          return obj;
-        });
-        response['&main.a.&uni_obj.&uni_obj_all']      = uniObjAll;
+
+        // PHP: only include 'object' and '&uni_obj_all' when there are actual objects
+        if (objRows.length > 0) {
+          response['object']                             = objRows.map(r => {
+            const obj = { id: String(r.id), val: r.val, up: String(r.up), base: String(r.base) };
+            // PHP #418: include ord when viewing child objects (f_u > 1)
+            if (fuParam && parseInt(fuParam, 10) > 1) obj.ord = String(r.ord || 0);
+            // PHP #419: include ref (raw val) for REPORT_COLUMN and GRANT base types
+            if (includeRef) obj.ref = r.val || '';
+            return obj;
+          });
+          response['&main.a.&uni_obj.&uni_obj_all']      = uniObjAll;
+        }
 
         if (hasReqs && Object.keys(reqsStd).length > 0) {
           response['reqs'] = reqsStd;
@@ -5716,13 +5732,25 @@ router.get('/:db/:page*', async (req, res, next) => {
           }
         }
 
-        // PHP includes &no_page only when page is full (objRows.length >= limit)
-        if (objRows.length >= (objLimit || 20)) {
+        // PHP #514: &no_page — PHP checks object_count == DEFAULT_LIMIT (20), ignoring
+        // custom LIMIT param. For API requests, object_count_total is never set so the
+        // condition reduces to: number of returned rows === DEFAULT_LIMIT (20).
+        const DEFAULT_LIMIT = 20;
+        if (objRows.length === DEFAULT_LIMIT) {
           response['&main.a.&uni_obj.&no_page'] = {
             id:    [String(typeId)],
             lnx:   [''],
             f_u:   [fuParam || '1'],
-            limit: [String(objLimit || 20)],
+            limit: [String(DEFAULT_LIMIT)],
+          };
+        }
+
+        // PHP #514: _NoObj block — PHP's template engine populates this whenever
+        // {_request_.f_u} resolves (i.e., F_U is present in the request), regardless
+        // of whether objects exist. It coexists with &uni_obj when objects are found.
+        if (allObjParams.F_U !== undefined) {
+          response['&main.a._noobj'] = {
+            '_request_.f_u': [String(filterUp !== null ? filterUp : '')]
           };
         }
 


### PR DESCRIPTION
## Summary

- **F_U=0**: Treat as "show all objects" (no parent filter) — PHP uses `vals.up != 0` for F_U=0, Node was incorrectly filtering by `a.up = 0` which contradicted the base `a.up != 0` condition
- **F_U + no results**: Return simplified `{&main.a, &main.a._noobj}` response when parent filter yields zero rows, matching PHP template engine behavior
- **_noobj block**: Always include `&main.a._noobj` with `_request_.f_u` when F_U is present in request params
- **Empty type**: Omit `object` array and `&uni_obj_all` block when query returns 0 rows (PHP template engine doesn't populate these blocks without data)
- **&no_page**: Only emit when returned row count equals DEFAULT_LIMIT (20), not when it equals a custom LIMIT parameter — PHP checks `object_count == DEFAULT_LIMIT` regardless of custom LIMIT

## Test plan

- [x] `node tests/comparison/04-listing.js` — tests #3-6 (LIMIT, empty, F_U=1, F_U=0) now MATCH
- [x] `node tests/comparison/07-refs-multi.js` — tests #9 (sub-type), #11 (F_U=parentId), #17 (col-as-table) now MATCH
- [x] Existing passing tests remain unaffected (18/21 in 04-listing, 17/19 in 07-refs-multi)
- [x] Remaining DIFFs are pre-existing ID offset issues between PHP/Node, not related to this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)