### PR TITLE
fix: await ACTIVITY update in auth middleware for PHP parity (#515)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -2738,12 +2738,17 @@ async function legacyAuthMiddleware(req, res, next) {
         }
 
         // PHP parity: update ACTIVITY timestamp on every authenticated request (index.php:1190-1193)
+        // PHP runs Exec_sql() synchronously so UPDATE commits before the page handler's
+        // SELECT.  We await to match that behaviour; this also guarantees that subsequent
+        // queries in this request see the value we just wrote.
         const actNow = String(Date.now() / 1000);
-        if (user.act_id) {
-          execSql(pool, `UPDATE \`${db}\` SET val = ? WHERE id = ?`, [actNow, user.act_id], { label: 'middleware_activity_update' }).catch(() => {});
-        } else {
-          execSql(pool, `INSERT INTO \`${db}\` (up, ord, t, val) VALUES (?, 0, ${TYPE.ACTIVITY}, ?)`, [user.uid, actNow], { label: 'middleware_activity_insert' }).catch(() => {});
-        }
+        try {
+          if (user.act_id) {
+            await execSql(pool, `UPDATE \`${db}\` SET val = ? WHERE id = ?`, [actNow, user.act_id], { label: 'middleware_activity_update' });
+          } else {
+            await execSql(pool, `INSERT INTO \`${db}\` (up, ord, t, val) VALUES (?, 0, ${TYPE.ACTIVITY}, ?)`, [user.uid, actNow], { label: 'middleware_activity_insert' });
+          }
+        } catch (_) { /* PHP's Exec_sql with $fatal=FALSE ignores errors */ }
 
         // PHP parity: secret auth — delete the cookie after validation (index.php:1194-1195)
         // PHP: setcookie($z, "", time() - 3600, "/") — removes the password cookie


### PR DESCRIPTION
## Summary

- Await the ACTIVITY timestamp UPDATE in `legacyAuthMiddleware` instead of fire-and-forget, matching PHP's synchronous `Exec_sql()` behaviour
- Wrap in try/catch to match PHP's `$fatal=FALSE` parameter (errors are silently ignored)
- This ensures the handler's subsequent SELECT always sees the freshly-written timestamp

## Root Cause

PHP's `Exec_sql("UPDATE ... SET val=microtime(TRUE) ...", ..., FALSE)` at index.php:1191 runs synchronously before the page handler.  The Node middleware was using fire-and-forget (`.catch(() => {})`), so the edit_types handler's SELECT could read a stale activity timestamp — or race with a concurrent request from another server that writes a different value to the same row.

## Remaining Test Diff

The 06-admin and 04-listing comparison tests still report `val[edit_types]` DIFF because the test framework sends requests to PHP and Node **in parallel** (`Promise.all`).  Both servers update the same `ACTIVITY` row (the testbot user's session timestamp) to different values, creating an inherent database-level race condition.  When requests are serialized, the responses match perfectly.

## Test plan

- [x] `node tests/comparison/06-admin.js` — test #6 (edit_types): no regression (14 MATCH, same as before)
- [x] `node tests/comparison/04-listing.js` — test #12 (edit_types): no regression
- [x] `node tests/comparison/01-auth.js` — 14 MATCH, no regression from await change
- [x] Serial comparison confirms zero structural diffs between PHP and Node edit_types responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)