### PR TITLE
fix: test normalize() gaps and edit_types race (#528-#533)

### DIFF
--- a/tests/comparison/04-listing.js
+++ b/tests/comparison/04-listing.js
@@ -79,7 +79,7 @@ async function run() {
     s => `/edit_obj/${objs[0][s]}?JSON=1`);
 
   // 12. GET /edit_types
-  await dual('GET /edit_types', 'GET', '/edit_types?JSON=1');
+  await dual('GET /edit_types', 'GET', '/edit_types?JSON=1', null, { keysOnly: true });
 
   // 13. GET /obj_meta/:typeId
   await dual('GET /obj_meta/:type', 'GET',

--- a/tests/comparison/06-admin.js
+++ b/tests/comparison/06-admin.js
@@ -43,7 +43,7 @@ async function run() {
   section('Edit Types');
 
   // 6. GET /edit_types?JSON=1
-  await dual('GET /edit_types?JSON=1', 'GET', '/edit_types?JSON=1');
+  await dual('GET /edit_types?JSON=1', 'GET', '/edit_types?JSON=1', null, { keysOnly: true });
 
   // 7. GET /types?JSON=1
   await dual('GET /types?JSON=1', 'GET', '/types?JSON=1', null, { statusOnly: true });

--- a/tests/comparison/lib.js
+++ b/tests/comparison/lib.js
@@ -66,7 +66,12 @@ function normalize(obj, depth = 0) {
     if (k === '_xsrf' || k === 'xsrf') { out[k] = '__XSRF__'; continue; }
     if (k === 'token') { out[k] = '__TOKEN__'; continue; }
     if (k === 'id' && (typeof v === 'number' || typeof v === 'string')) { out[k] = '__ID__'; continue; }
+    if (k === 'id' && Array.isArray(v)) { out[k] = v.map(() => '__ID__'); continue; }
     if (k === 'obj' && (typeof v === 'number' || typeof v === 'string')) { out[k] = '__ID__'; continue; }
+    if (k === 'obj' && Array.isArray(v)) { out[k] = v.map(() => '__ID__'); continue; }
+    if (k === 'ord') { out[k] = '__ORD__'; continue; }
+    if (k === 'val' && typeof v === 'string' && /^\d+$/.test(v) && obj.ord !== undefined) { out[k] = '__ORD__'; continue; }
+    if (k === 'args' && typeof v === 'string') { out[k] = v.replace(/F_I=\d+/g, 'F_I=__ID__'); continue; }
     out[k] = normalize(v, depth + 1);
   }
   return out;


### PR DESCRIPTION
## Summary
- **#531**: `normalize()` now handles `id` and `obj` when they are arrays (maps each element to `__ID__`)
- **#533**: `normalize()` now handles `ord` fields, numeric `val` linked to `ord`, `args` strings with `F_I=` params, and `obj` arrays
- **#532**: `edit_types` dual() calls in `04-listing.js` and `06-admin.js` use `keysOnly: true` to avoid false diffs from timestamp race conditions
- **#528, #530**: Verified that `07-refs-multi.js` already uses per-server IDs correctly via `parentObj1[s]` and `colAsTableRef[s]`

## Changed files
- `tests/comparison/lib.js` — 5 new normalization rules in `normalize()`
- `tests/comparison/04-listing.js` — `keysOnly` option on edit_types test
- `tests/comparison/06-admin.js` — `keysOnly` option on edit_types test

## Test plan
- [ ] `node 03-dml.js` — tests #1-4 should be MATCH
- [ ] `node 04-listing.js` — test #12 (edit_types) should be MATCH
- [ ] `node 06-admin.js` — test #6 (edit_types) should be MATCH
- [ ] `node 07-refs-multi.js` — tests #11, #18, #19 should be MATCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)