### PR TITLE
fix: dir_admin HTML parity with PHP (closes #529)

### DIFF
--- a/backend/monolith/src/api/routes/legacy-compat.js
+++ b/backend/monolith/src/api/routes/legacy-compat.js
@@ -10789,8 +10789,9 @@ router.get('/:db/dir_admin', legacyAuthMiddleware, async (req, res) => {
   }
 
   try {
-    // PHP: download=1 → show download/{db}/ folder; download=0 or absent → templates/custom/{db}/
-    const useDownload = download !== undefined && download !== '0' && download !== 'false';
+    // PHP parity: isset($_REQUEST["download"]) — true whenever ?download is present in query
+    // string, regardless of its value (even ?download=0). Only absent → templates mode.
+    const useDownload = download !== undefined;
     const basePath = useDownload
       ? path.join(legacyPath, 'download', db)
       : path.join(legacyPath, 'templates', 'custom', db);


### PR DESCRIPTION
## Summary
- The `GET /dir_admin?JSON=1` HTML body now matches PHP byte-for-byte (verified via md5sum)
- Fixed `?download` query parameter handling to match PHP's `isset()` semantics: any present parameter (even `?download=0`) activates download folder mode, matching PHP behavior
- The core HTML template rendering (makeTreeInner + parseBlock pipeline) was already correct from PR #522 and subsequent fixes

## Verification
```
md5sum /tmp/php_dir.html /tmp/node_dir.html
9aae941c85d575f509167776f80e5143  /tmp/php_dir.html
9aae941c85d575f509167776f80e5143  /tmp/node_dir.html
```

Test 06-admin #12 passes as MATCH (15/16 tests pass; the 1 DIFF is edit_types, a separate issue).

## Test plan
- [x] `node tests/comparison/06-admin.js` -- test #12 (dir_admin) passes
- [x] Direct curl comparison: PHP and Node return identical HTML (md5 match)
- [x] No test files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)