### PR TITLE
fix: const→let for photoColumn to fix Vite startup

### DIFF
--- a/src/components/integram/DataTable/composables/useUserMentions.js
+++ b/src/components/integram/DataTable/composables/useUserMentions.js
@@ -90,7 +90,7 @@ export function useUserMentions(database) {
         })
 
         // Find photo column by matching against PHOTO_COLUMNS patterns
-        const photoColumn = requisites.find(req => {
+        let photoColumn = requisites.find(req => {
           const name = (req.alias || req.val || '').toLowerCase()
           return PHOTO_COLUMNS.some(pattern => name.includes(pattern))
         })


### PR DESCRIPTION
## Summary
- `const photoColumn` in `useUserMentions.js` was reassigned on line 112 (fallback path), which is a JS error
- esbuild dependency scan failed on this error, preventing Vite dev server from resolving modules (manifested as `router/index.js does not provide an export named 'default'`)
- Changed `const` to `let` to allow the fallback reassignment

## Test plan
- [ ] `npm run dev` starts without errors
- [ ] User mentions with photo column fallback still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)